### PR TITLE
fix(scanner): populate File and Line in validator AnnotationErrors (#28)

### DIFF
--- a/scanner/go_parser.go
+++ b/scanner/go_parser.go
@@ -131,5 +131,7 @@ func buildRoute(file string, line int, routeAnnot, validateAnnot, authAnnot, wor
 		AuthRoles: roles,
 		Validate:  validate,
 		Type:      "api",
+		File:      file,
+		Line:      line,
 	}, nil
 }

--- a/scanner/ts_parser.go
+++ b/scanner/ts_parser.go
@@ -149,5 +149,7 @@ func buildTSRoute(file string, line int, routeAnnot, pageAnnot, validateAnnot, a
 		AuthRoles: roles,
 		Validate:  validate,
 		Type:      routeType,
+		File:      file,
+		Line:      line,
 	}, nil
 }

--- a/scanner/types.go
+++ b/scanner/types.go
@@ -8,6 +8,10 @@ type Route struct {
 	AuthRoles []string `json:"auth_roles"`
 	Validate  string   `json:"validate"`
 	Type      string   `json:"type"` // "api" or "page"
+
+	// Source location — populated by parsers, excluded from route_map.json.
+	File string `json:"-"`
+	Line int    `json:"-"`
 }
 
 // AnnotationError holds information about a malformed annotation.

--- a/scanner/validator.go
+++ b/scanner/validator.go
@@ -11,6 +11,7 @@ var validMethods = map[string]bool{
 }
 
 // Validate checks each route for correctness and returns semantic errors.
+// Each AnnotationError includes the File and Line from the originating Route.
 func Validate(routes []Route) []AnnotationError {
 	var errs []AnnotationError
 	seen := map[string]bool{}
@@ -18,17 +19,23 @@ func Validate(routes []Route) []AnnotationError {
 	for _, r := range routes {
 		if !validMethods[r.Method] {
 			errs = append(errs, AnnotationError{
+				File:    r.File,
+				Line:    r.Line,
 				Message: fmt.Sprintf("unknown HTTP method %q on route %s", r.Method, r.Path),
 			})
 		}
 		if !strings.HasPrefix(r.Path, "/") {
 			errs = append(errs, AnnotationError{
+				File:    r.File,
+				Line:    r.Line,
 				Message: fmt.Sprintf("route path %q must start with /", r.Path),
 			})
 		}
 		key := r.Method + " " + r.Path
 		if seen[key] {
 			errs = append(errs, AnnotationError{
+				File:    r.File,
+				Line:    r.Line,
 				Message: fmt.Sprintf("duplicate route %s %s", r.Method, r.Path),
 			})
 		}

--- a/scanner/validator_test.go
+++ b/scanner/validator_test.go
@@ -1,0 +1,78 @@
+package scanner
+
+import "testing"
+
+func TestValidate_InvalidMethod(t *testing.T) {
+	routes := []Route{
+		{Path: "/api/test", Method: "INVALID", File: "handler.go", Line: 10},
+	}
+	errs := Validate(routes)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+	if errs[0].File != "handler.go" {
+		t.Errorf("expected File %q, got %q", "handler.go", errs[0].File)
+	}
+	if errs[0].Line != 10 {
+		t.Errorf("expected Line 10, got %d", errs[0].Line)
+	}
+}
+
+func TestValidate_PathMissingSlash(t *testing.T) {
+	routes := []Route{
+		{Path: "api/missing-slash", Method: "GET", File: "routes.ts", Line: 42},
+	}
+	errs := Validate(routes)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+	if errs[0].File != "routes.ts" {
+		t.Errorf("expected File %q, got %q", "routes.ts", errs[0].File)
+	}
+	if errs[0].Line != 42 {
+		t.Errorf("expected Line 42, got %d", errs[0].Line)
+	}
+}
+
+func TestValidate_DuplicateRoute(t *testing.T) {
+	routes := []Route{
+		{Path: "/api/users", Method: "GET", File: "users.go", Line: 5},
+		{Path: "/api/users", Method: "GET", File: "users.go", Line: 20},
+	}
+	errs := Validate(routes)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(errs))
+	}
+	if errs[0].File != "users.go" {
+		t.Errorf("expected File %q, got %q", "users.go", errs[0].File)
+	}
+	if errs[0].Line != 20 {
+		t.Errorf("expected Line 20, got %d", errs[0].Line)
+	}
+}
+
+func TestValidate_ValidRoutes_NoErrors(t *testing.T) {
+	routes := []Route{
+		{Path: "/api/products", Method: "GET", File: "products.go", Line: 8},
+		{Path: "/api/products", Method: "POST", File: "products.go", Line: 15},
+	}
+	errs := Validate(routes)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidate_ErrorMessage_ContainsLocation(t *testing.T) {
+	routes := []Route{
+		{Path: "/api/test", Method: "BOGUS", File: "svc.go", Line: 7},
+	}
+	errs := Validate(routes)
+	if len(errs) == 0 {
+		t.Fatal("expected an error")
+	}
+	msg := errs[0].Error()
+	expected := "svc.go:7:"
+	if len(msg) < len(expected) || msg[:len(expected)] != expected {
+		t.Errorf("expected error to start with %q, got %q", expected, msg)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #28.

The `validator.go` was returning `AnnotationError`s with empty `File` and zero `Line`, even though the `AnnotationError` struct already supported those fields. This PR propagates source location through the entire scanner pipeline.

## Changes

### `scanner/types.go`
- Added `File string` and `Line int` fields to the `Route` struct
- Tagged both with `json:"-"` so they are **not** serialised into `route_map.json`

### `scanner/go_parser.go`
- `buildRoute()` now sets `File` and `Line` on the returned `Route`

### `scanner/ts_parser.go`
- `buildTSRoute()` now sets `File` and `Line` on the returned `Route`

### `scanner/validator.go`
- All three `AnnotationError` constructions now propagate `r.File` and `r.Line` from the originating `Route`
- Added doc comment explaining the new behaviour

### `scanner/validator_test.go` ✨ new file
- `TestValidate_InvalidMethod` — asserts `File` and `Line` on invalid HTTP method error
- `TestValidate_PathMissingSlash` — asserts `File` and `Line` on missing `/` prefix
- `TestValidate_DuplicateRoute` — asserts `File` and `Line` on duplicate route error
- `TestValidate_ValidRoutes_NoErrors` — regression: valid routes produce no errors
- `TestValidate_ErrorMessage_ContainsLocation` — asserts `.Error()` output starts with `file:line:`

## Before / After

```
// Before
errs = append(errs, AnnotationError{
    Message: fmt.Sprintf("unknown HTTP method %q ..."),
    // File and Line were zero-values
})

// After
errs = append(errs, AnnotationError{
    File:    r.File,
    Line:    r.Line,
    Message: fmt.Sprintf("unknown HTTP method %q ..."),
})
```

## Testing

```bash
cd scanner && go test ./...
```

All existing tests (`go_parser_test.go`, `ts_parser_test.go`) continue to pass. Five new tests added in `validator_test.go`.