### PR TITLE
fix(heartbeat): send TypeHeartbeat frames from core to workers every 5s (#29)

### DIFF
--- a/core/application/heartbeat/sender.go
+++ b/core/application/heartbeat/sender.go
@@ -1,0 +1,87 @@
+package heartbeat
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// WorkerLister is the subset of the worker repository used by the Sender
+// to discover which workers are currently alive.
+type WorkerLister interface {
+	LiveWorkerIDs(ctx context.Context) ([]string, error)
+}
+
+// Sender periodically sends a TypeHeartbeat frame from the core to every
+// connected worker over the IPC transport. This lets workers detect core
+// unavailability independently of the worker→core heartbeat loop.
+//
+// The Sender is the application-layer owner of the core→worker heartbeat;
+// the OS process manager (infrastructure/process) is intentionally kept
+// free of transport concerns.
+type Sender struct {
+	transport ipc.Transport
+	lister    WorkerLister
+	cfg       Config
+	log       *zap.Logger
+}
+
+// NewSender creates a Sender that writes heartbeat frames to all live workers.
+func NewSender(
+	transport ipc.Transport,
+	lister WorkerLister,
+	cfg Config,
+	log *zap.Logger,
+) *Sender {
+	return &Sender{
+		transport: transport,
+		lister:    lister,
+		cfg:       cfg,
+		log:       log,
+	}
+}
+
+// Run starts the heartbeat send loop. It ticks every cfg.Interval, fetches
+// the list of live worker IDs, and sends a TypeHeartbeat frame to each one.
+// Blocks until ctx is cancelled.
+func (s *Sender) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sendAll(ctx)
+		}
+	}
+}
+
+// sendAll sends a TypeHeartbeat frame to every live worker.
+// A failure for one worker is logged and skipped — it must not block others.
+func (s *Sender) sendAll(ctx context.Context) {
+	ids, err := s.lister.LiveWorkerIDs(ctx)
+	if err != nil {
+		s.log.Error("heartbeat sender: failed to list workers", zap.Error(err))
+		return
+	}
+
+	msg := ipc.Message{Type: ipc.TypeHeartbeat, Payload: []byte{}}
+
+	for _, id := range ids {
+		if err := s.transport.Send(ctx, id, msg); err != nil {
+			s.log.Warn("heartbeat sender: failed to send heartbeat to worker",
+				zap.String("worker_id", id),
+				zap.Error(err),
+			)
+			continue
+		}
+		s.log.Debug("heartbeat sender: sent heartbeat",
+			zap.String("worker_id", id),
+		)
+	}
+}

--- a/core/application/heartbeat/sender_test.go
+++ b/core/application/heartbeat/sender_test.go
@@ -1,0 +1,152 @@
+package heartbeat_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ElioNeto/vyx/core/application/heartbeat"
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// mockLister returns a fixed list of worker IDs.
+type mockLister struct {
+	ids []string
+}
+
+func (m *mockLister) LiveWorkerIDs(_ context.Context) ([]string, error) {
+	return m.ids, nil
+}
+
+// recordingTransport records every Send call.
+type recordingTransport struct {
+	mu      sync.Mutex
+	sent    []ipc.Message
+	workers []string
+}
+
+func (r *recordingTransport) Send(_ context.Context, workerID string, msg ipc.Message) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sent = append(r.sent, msg)
+	r.workers = append(r.workers, workerID)
+	return nil
+}
+func (r *recordingTransport) Receive(_ context.Context, _ string) (ipc.Message, error) {
+	return ipc.Message{}, nil
+}
+func (r *recordingTransport) Register(_ context.Context, _ string) error   { return nil }
+func (r *recordingTransport) Deregister(_ context.Context, _ string) error { return nil }
+func (r *recordingTransport) Close() error                                  { return nil }
+
+func TestSender_SendsHeartbeatFrame(t *testing.T) {
+	transport := &recordingTransport{}
+	lister := &mockLister{ids: []string{"worker-1", "worker-2"}}
+
+	cfg := heartbeat.Config{Interval: 30 * time.Millisecond, MissedThreshold: 2}
+	sender := heartbeat.NewSender(transport, lister, cfg, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Millisecond)
+	defer cancel()
+
+	sender.Run(ctx)
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+
+	if len(transport.sent) < 2 {
+		t.Fatalf("expected at least 2 sends (one per worker per tick), got %d", len(transport.sent))
+	}
+	for i, msg := range transport.sent {
+		if msg.Type != ipc.TypeHeartbeat {
+			t.Errorf("send[%d]: expected TypeHeartbeat (0x03), got 0x%02x", i, msg.Type)
+		}
+	}
+}
+
+func TestSender_SendsToAllWorkers(t *testing.T) {
+	transport := &recordingTransport{}
+	lister := &mockLister{ids: []string{"node:api", "go:billing", "python:ml"}}
+
+	cfg := heartbeat.Config{Interval: 20 * time.Millisecond, MissedThreshold: 2}
+	sender := heartbeat.NewSender(transport, lister, cfg, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	sender.Run(ctx)
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+
+	seen := map[string]bool{}
+	for _, id := range transport.workers {
+		seen[id] = true
+	}
+	for _, expected := range []string{"node:api", "go:billing", "python:ml"} {
+		if !seen[expected] {
+			t.Errorf("expected heartbeat sent to %q, but it was not", expected)
+		}
+	}
+}
+
+func TestSender_ContextCancelled_ExitsCleanly(t *testing.T) {
+	transport := &recordingTransport{}
+	lister := &mockLister{ids: []string{"worker-1"}}
+
+	cfg := heartbeat.Config{Interval: 50 * time.Millisecond, MissedThreshold: 2}
+	sender := heartbeat.NewSender(transport, lister, cfg, zap.NewNop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		sender.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// clean exit
+	case <-time.After(2 * time.Second):
+		t.Error("Sender.Run did not exit after context cancellation")
+	}
+}
+
+func TestSender_SendError_DoesNotPanic(t *testing.T) {
+	// Transport that always fails on Send
+	failTransport := &failingSendTransport{}
+	lister := &mockLister{ids: []string{"worker-broken"}}
+
+	cfg := heartbeat.Config{Interval: 20 * time.Millisecond, MissedThreshold: 2}
+	sender := heartbeat.NewSender(failTransport, lister, cfg, zap.NewNop())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+
+	// Must not panic
+	sender.Run(ctx)
+}
+
+// failingSendTransport always returns an error on Send.
+type failingSendTransport struct{}
+
+func (f *failingSendTransport) Send(_ context.Context, _ string, _ ipc.Message) error {
+	return &mockSendError{}
+}
+func (f *failingSendTransport) Receive(_ context.Context, _ string) (ipc.Message, error) {
+	return ipc.Message{}, nil
+}
+func (f *failingSendTransport) Register(_ context.Context, _ string) error   { return nil }
+func (f *failingSendTransport) Deregister(_ context.Context, _ string) error { return nil }
+func (f *failingSendTransport) Close() error                                  { return nil }
+
+type mockSendError struct{}
+
+func (e *mockSendError) Error() string { return "send failed" }

--- a/core/infrastructure/process/manager.go
+++ b/core/infrastructure/process/manager.go
@@ -108,7 +108,9 @@ func (m *Manager) StopAll(ctx context.Context) error {
 	return lastErr
 }
 
-// SendHeartbeat is a no-op at the OS process level; heartbeats are handled via UDS.
+// SendHeartbeat is not implemented at the OS process layer.
+// Core→worker heartbeat frames are sent by application/heartbeat.Sender
+// over the IPC transport — keeping this manager focused on spawn/stop only.
 func (m *Manager) SendHeartbeat(_ context.Context, _ string) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes #29.

O `process/manager.go` tinha um `SendHeartbeat` explicitamente no-op. Isso significa que nenhum frame `TypeHeartbeat` era enviado do core para os workers via UDS, violando o critério da Issue #2 (_"Core and worker exchange heartbeat messages every 5s"_).

Este PR resolve o problema na camada correta (aplicação), sem contaminar o manager de processos com responsabilidades de transporte.

## Decisão de design

O `SendHeartbeat` permanece um no-op no `process/manager.go` por design: o manager de processos é responsável apenas por `Spawn`/`Stop` em nível de OS. A responsabilidade de enviar frames IPC pertence à camada de aplicação. Por isso, o novo `heartbeat.Sender` foi criado nessa camada, usando `ipc.Transport.Send` diretamente.

## Alterações

### `core/application/heartbeat/sender.go` ✨ novo
- `Sender` recebe um `ipc.Transport` e um `WorkerLister` (interface mínima e testável)
- `Run(ctx)` faz tick a cada `cfg.Interval` e chama `sendAll`
- `sendAll` busca todos os worker IDs vivos e envia `ipc.Message{Type: ipc.TypeHeartbeat}` para cada um via `transport.Send`
- Falha em um worker é **logada e skipada** — não bloqueia os demais

### `core/application/heartbeat/sender_test.go` ✨ novo
| Teste | Cobertura |
|---|---|
| `TestSender_SendsHeartbeatFrame` | Verifica que frames `TypeHeartbeat` são enviados |
| `TestSender_SendsToAllWorkers` | Verifica que todos os workers recebem o ping |
| `TestSender_ContextCancelled_ExitsCleanly` | Verifica saída limpa ao cancelar ctx |
| `TestSender_SendError_DoesNotPanic` | Verifica tolerância a erros de Send |

### `core/infrastructure/process/manager.go`
- Comentário do `SendHeartbeat` atualizado para documentar a decisão arquitetural

## Como executar

```bash
cd core && go test ./application/heartbeat/...
```

## Wiring (próximo passo)

O `Sender` precisa ser instanciado e iniciado (`go sender.Run(ctx)`) no ponto de entrada do core (`core/cmd`), junto com o `heartbeat.Loop` já existente. Isso será feito como parte da Issue #5 (CLI / `vyx dev`).