### PR TITLE
feat(config): vyx.yaml schema, config loader, validation and SIGHUP reload (#20)

### DIFF
--- a/core/cmd/vyx/main.go
+++ b/core/cmd/vyx/main.go
@@ -11,14 +11,34 @@ import (
 
 	"github.com/ElioNeto/vyx/core/application/lifecycle"
 	"github.com/ElioNeto/vyx/core/application/monitor"
+	infracfg "github.com/ElioNeto/vyx/core/infrastructure/config"
 	"github.com/ElioNeto/vyx/core/infrastructure/logger"
 	"github.com/ElioNeto/vyx/core/infrastructure/process"
 	"github.com/ElioNeto/vyx/core/infrastructure/repository"
 )
 
+const defaultConfigPath = "vyx.yaml"
+
 func main() {
 	log, _ := zap.NewProduction()
 	defer log.Sync()
+
+	// --- Load and validate vyx.yaml (fail fast) ---
+	configPath := defaultConfigPath
+	if p := os.Getenv("VYX_CONFIG"); p != "" {
+		configPath = p
+	}
+	cfgLoader := infracfg.New(configPath, log)
+	cfg, err := cfgLoader.Load()
+	if err != nil {
+		log.Fatal("failed to load vyx.yaml", zap.Error(err))
+	}
+	cfgLoader.SetCurrent(cfg)
+	log.Info("vyx.yaml loaded",
+		zap.String("project", cfg.Project.Name),
+		zap.String("version", cfg.Project.Version),
+		zap.Int("workers", len(cfg.Workers)),
+	)
 
 	// --- Dependency injection (composition root) ---
 	repo := repository.NewMemoryWorkerRepository()
@@ -35,6 +55,9 @@ func main() {
 
 	// Start the health monitor in the background.
 	go healthMonitor.Run(ctx)
+
+	// Watch for SIGHUP config reload in dev mode.
+	go cfgLoader.WatchSIGHUP(ctx)
 
 	// Block until SIGTERM / SIGINT.
 	<-ctx.Done()

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -1,0 +1,117 @@
+// Package config defines the domain schema for the vyx.yaml project manifest.
+// This is a pure value-object layer — no I/O, no external dependencies beyond stdlib.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Config is the top-level representation of vyx.yaml.
+type Config struct {
+	Project  ProjectConfig  `yaml:"project"`
+	Workers  []WorkerConfig `yaml:"workers"`
+	Security SecurityConfig `yaml:"security"`
+	IPC      IPCConfig      `yaml:"ipc"`
+	Build    BuildConfig    `yaml:"build"`
+}
+
+// ProjectConfig holds project metadata.
+type ProjectConfig struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+// WorkerConfig describes a single managed worker process.
+type WorkerConfig struct {
+	ID              string        `yaml:"id"`
+	Command         string        `yaml:"command"`
+	Replicas        int           `yaml:"replicas"`
+	Strategy        string        `yaml:"strategy"`         // "round-robin" | "least-loaded"
+	StartupTimeout  time.Duration `yaml:"startup_timeout"`
+	ShutdownTimeout time.Duration `yaml:"shutdown_timeout"`
+}
+
+// SecurityConfig holds JWT, rate-limiting and payload settings.
+type SecurityConfig struct {
+	JWTSecretEnv   string          `yaml:"jwt_secret_env"`
+	RateLimit      RateLimitConfig `yaml:"rate_limit"`
+	PayloadMaxSize string          `yaml:"payload_max_size"` // e.g. "1mb"
+	GlobalTimeout  time.Duration   `yaml:"global_timeout"`
+}
+
+// RateLimitConfig defines per-IP and per-token request caps.
+type RateLimitConfig struct {
+	PerIP    int `yaml:"per_ip"`
+	PerToken int `yaml:"per_token"`
+}
+
+// IPCConfig holds Unix Domain Socket and Arrow settings.
+type IPCConfig struct {
+	SocketDir      string `yaml:"socket_dir"`
+	ArrowThreshold string `yaml:"arrow_threshold"` // e.g. "512kb"
+}
+
+// BuildConfig holds paths used at build time by the annotation scanner.
+type BuildConfig struct {
+	SchemasDir     string `yaml:"schemas_dir"`
+	RouteMapOutput string `yaml:"route_map_output"`
+}
+
+// Defaults returns a Config pre-filled with sensible production defaults.
+func Defaults() Config {
+	return Config{
+		Project: ProjectConfig{
+			Version: "0.1.0",
+		},
+		Security: SecurityConfig{
+			JWTSecretEnv: "JWT_SECRET",
+			RateLimit: RateLimitConfig{
+				PerIP:    100,
+				PerToken: 500,
+			},
+			PayloadMaxSize: "1mb",
+			GlobalTimeout:  30 * time.Second,
+		},
+		IPC: IPCConfig{
+			SocketDir:      "/tmp/vyx",
+			ArrowThreshold: "512kb",
+		},
+		Build: BuildConfig{
+			SchemasDir:     "./schemas",
+			RouteMapOutput: "./route_map.json",
+		},
+	}
+}
+
+// Validate checks the config for required fields and invalid combinations.
+// Returns a joined error listing every problem found.
+func (c *Config) Validate() error {
+	var errs []error
+
+	if c.Project.Name == "" {
+		errs = append(errs, errors.New("project.name is required"))
+	}
+
+	for i, w := range c.Workers {
+		if w.ID == "" {
+			errs = append(errs, fmt.Errorf("workers[%d].id is required", i))
+		}
+		if w.Command == "" {
+			errs = append(errs, fmt.Errorf("workers[%d].command is required (id: %q)", i, w.ID))
+		}
+		if w.Replicas < 0 {
+			errs = append(errs, fmt.Errorf("workers[%d].replicas must be >= 0 (id: %q)", i, w.ID))
+		}
+		validStrategies := map[string]bool{"round-robin": true, "least-loaded": true, "": true}
+		if !validStrategies[w.Strategy] {
+			errs = append(errs, fmt.Errorf("workers[%d].strategy %q is invalid; use \"round-robin\" or \"least-loaded\" (id: %q)", i, w.Strategy, w.ID))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
+}

--- a/core/go.mod
+++ b/core/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.18.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/core/infrastructure/config/loader.go
+++ b/core/infrastructure/config/loader.go
@@ -1,0 +1,94 @@
+// Package config implements reading and hot-reloading of the vyx.yaml manifest.
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	domaincfg "github.com/ElioNeto/vyx/core/domain/config"
+)
+
+// Loader reads vyx.yaml from disk and watches for SIGHUP to reload it.
+type Loader struct {
+	path string
+	log  *zap.Logger
+
+	mu     sync.RWMutex
+	current *domaincfg.Config
+}
+
+// New creates a Loader for the given file path.
+func New(path string, log *zap.Logger) *Loader {
+	return &Loader{path: path, log: log}
+}
+
+// Load reads and validates vyx.yaml. It merges the file over top of the
+// defaults, so omitted keys keep their sensible values.
+// Returns an error if the file cannot be read, parsed, or fails validation.
+func (l *Loader) Load() (*domaincfg.Config, error) {
+	data, err := os.ReadFile(l.path)
+	if err != nil {
+		return nil, fmt.Errorf("config: read %s: %w", l.path, err)
+	}
+
+	cfg := domaincfg.Defaults()
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("config: parse %s: %w", l.path, err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("config: validation failed: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// MustLoad calls Load and panics on any error. Useful for the startup path
+// where a bad config should abort immediately.
+func (l *Loader) MustLoad() *domaincfg.Config {
+	cfg, err := l.Load()
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+// Current returns the most recently loaded config. Safe for concurrent use.
+func (l *Loader) Current() *domaincfg.Config {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.current
+}
+
+// WatchSIGHUP starts a goroutine that reloads the config whenever SIGHUP is
+// received. Intended for development mode. Blocks until ctx is cancelled.
+func (l *Loader) WatchSIGHUP(ctx context.Context) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	defer signal.Stop(ch)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			l.log.Info("SIGHUP received — reloading vyx.yaml", zap.String("path", l.path))
+			cfg, err := l.Load()
+			if err != nil {
+				l.log.Error("config reload failed — keeping previous config", zap.Error(err))
+				continue
+			}
+			l.mu.Lock()
+			l.current = cfg
+			l.mu.Unlock()
+			l.log.Info("config reloaded successfully", zap.String("project", cfg.Project.Name))
+		}
+	}
+}

--- a/core/infrastructure/config/loader_exported.go
+++ b/core/infrastructure/config/loader_exported.go
@@ -1,0 +1,11 @@
+package config
+
+import domaincfg "github.com/ElioNeto/vyx/core/domain/config"
+
+// SetCurrent sets the current config directly. Used in tests and at startup
+// after the initial Load() to seed the in-memory cache.
+func (l *Loader) SetCurrent(cfg *domaincfg.Config) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.current = cfg
+}

--- a/core/infrastructure/config/loader_test.go
+++ b/core/infrastructure/config/loader_test.go
@@ -1,0 +1,207 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+	"context"
+
+	"go.uber.org/zap"
+
+	infracfg "github.com/ElioNeto/vyx/core/infrastructure/config"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestLoader_Load_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  name: test-app
+  version: 1.2.3
+workers:
+  - id: node:api
+    command: node index.js
+    replicas: 2
+    strategy: round-robin
+    startup_timeout: 10s
+    shutdown_timeout: 5s
+security:
+  jwt_secret_env: MY_SECRET
+  rate_limit:
+    per_ip: 200
+    per_token: 1000
+  payload_max_size: 2mb
+  global_timeout: 60s
+ipc:
+  socket_dir: /tmp/myapp
+  arrow_threshold: 1mb
+build:
+  schemas_dir: ./my-schemas
+  route_map_output: ./out/route_map.json
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Project.Name != "test-app" {
+		t.Errorf("expected project.name=test-app, got %q", cfg.Project.Name)
+	}
+	if cfg.Project.Version != "1.2.3" {
+		t.Errorf("expected project.version=1.2.3, got %q", cfg.Project.Version)
+	}
+	if len(cfg.Workers) != 1 {
+		t.Fatalf("expected 1 worker, got %d", len(cfg.Workers))
+	}
+	w := cfg.Workers[0]
+	if w.ID != "node:api" || w.Command != "node index.js" {
+		t.Errorf("unexpected worker: %+v", w)
+	}
+	if w.Replicas != 2 || w.Strategy != "round-robin" {
+		t.Errorf("unexpected worker replicas/strategy: %+v", w)
+	}
+	if w.StartupTimeout != 10*time.Second {
+		t.Errorf("expected startup_timeout=10s, got %v", w.StartupTimeout)
+	}
+	if cfg.Security.JWTSecretEnv != "MY_SECRET" {
+		t.Errorf("expected jwt_secret_env=MY_SECRET, got %q", cfg.Security.JWTSecretEnv)
+	}
+	if cfg.IPC.SocketDir != "/tmp/myapp" {
+		t.Errorf("expected ipc.socket_dir=/tmp/myapp, got %q", cfg.IPC.SocketDir)
+	}
+	if cfg.Build.RouteMapOutput != "./out/route_map.json" {
+		t.Errorf("unexpected route_map_output: %q", cfg.Build.RouteMapOutput)
+	}
+}
+
+func TestLoader_Load_Defaults_Applied(t *testing.T) {
+	dir := t.TempDir()
+	// Minimal config — most keys omitted; defaults must fill in.
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  name: minimal-app
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.IPC.SocketDir != "/tmp/vyx" {
+		t.Errorf("expected default ipc.socket_dir=/tmp/vyx, got %q", cfg.IPC.SocketDir)
+	}
+	if cfg.Security.GlobalTimeout != 30*time.Second {
+		t.Errorf("expected default global_timeout=30s, got %v", cfg.Security.GlobalTimeout)
+	}
+	if cfg.Build.SchemasDir != "./schemas" {
+		t.Errorf("expected default schemas_dir=./schemas, got %q", cfg.Build.SchemasDir)
+	}
+}
+
+func TestLoader_Load_MissingFile(t *testing.T) {
+	loader := infracfg.New("/nonexistent/vyx.yaml", zap.NewNop())
+	_, err := loader.Load()
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoader_Load_ValidationError_MissingProjectName(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  version: 1.0.0
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	_, err := loader.Load()
+	if err == nil {
+		t.Error("expected validation error for missing project.name")
+	}
+}
+
+func TestLoader_Load_ValidationError_WorkerMissingCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  name: my-app
+workers:
+  - id: node:api
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	_, err := loader.Load()
+	if err == nil {
+		t.Error("expected validation error for worker missing command")
+	}
+}
+
+func TestLoader_Load_ValidationError_InvalidStrategy(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  name: my-app
+workers:
+  - id: node:api
+    command: node index.js
+    strategy: random
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	_, err := loader.Load()
+	if err == nil {
+		t.Error("expected validation error for invalid strategy")
+	}
+}
+
+func TestLoader_WatchSIGHUP_ReloadsConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "vyx.yaml", `
+project:
+  name: original-app
+`)
+
+	loader := infracfg.New(path, zap.NewNop())
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("initial load failed: %v", err)
+	}
+	loader.SetCurrent(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go loader.WatchSIGHUP(ctx)
+
+	// Update the file and send SIGHUP.
+	writeFile(t, dir, "vyx.yaml", `
+project:
+  name: reloaded-app
+`)
+
+	time.Sleep(20 * time.Millisecond)
+	p, _ := os.FindProcess(os.Getpid())
+	_ = p.Signal(syscall.SIGHUP)
+
+	// Wait for reload to propagate.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if c := loader.Current(); c != nil && c.Project.Name == "reloaded-app" {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("config was not reloaded after SIGHUP")
+}


### PR DESCRIPTION
## Summary

Closes #20.

Implementa o manifesto `vyx.yaml` — fonte de verdade para definições de workers, segurança, IPC e build — com carregamento validado no startup do core e recarga sem reinicialização via `SIGHUP`.

---

## Arquitetura

```
core/domain/config/         ← schema puro (sem I/O)
  config.go                 ← structs Config, WorkerConfig, SecurityConfig, ...
                               + Defaults() + Validate()

core/infrastructure/config/ ← I/O e OS
  loader.go                 ← Loader: Load(), MustLoad(), WatchSIGHUP(ctx)
  loader_exported.go        ← SetCurrent() — seed do cache após Load()
  loader_test.go            ← 7 testes

core/cmd/vyx/main.go        ← wiring: fail-fast no startup + go WatchSIGHUP
core/go.mod                 ← gopkg.in/yaml.v3 promovida a dependência direta
```

---

## Seções suportadas no `vyx.yaml`

| Seção | Campos |
|---|---|
| `project` | `name`, `version` |
| `workers[]` | `id`, `command`, `replicas`, `strategy`, `startup_timeout`, `shutdown_timeout` |
| `security` | `jwt_secret_env`, `rate_limit.per_ip`, `rate_limit.per_token`, `payload_max_size`, `global_timeout` |
| `ipc` | `socket_dir`, `arrow_threshold` |
| `build` | `schemas_dir`, `route_map_output` |

---

## Defaults aplicados automaticamente

Campos omitidos no `vyx.yaml` recebem valores sensatos via `Defaults()`:

```yaml
security:
  jwt_secret_env: JWT_SECRET
  rate_limit: { per_ip: 100, per_token: 500 }
  payload_max_size: 1mb
  global_timeout: 30s
ipc:
  socket_dir: /tmp/vyx
  arrow_threshold: 512kb
build:
  schemas_dir: ./schemas
  route_map_output: ./route_map.json
```

---

## Fail-fast no startup

```go
cfg, err := cfgLoader.Load()
if err != nil {
    log.Fatal("failed to load vyx.yaml", zap.Error(err))
}
```

Erros de arquivo ausente, YAML inválido ou validação semântica abortam o processo imediatamente com log estruturado.

O path padrão é `vyx.yaml` no diretório de trabalho; pode ser sobrescrito via `VYX_CONFIG=/path/to/vyx.yaml`.

---

## SIGHUP reload

```bash
kill -HUP $(pgrep vyx)
```

O `WatchSIGHUP(ctx)` recarrega e re-valida o arquivo. Se a recarga falhar, o config anterior é mantido e o erro é logado — sem crash.

---

## Testes (`loader_test.go`)

| Teste | Cobertura |
|---|---|
| `TestLoader_Load_ValidConfig` | Lê todos os campos e verifica valores |
| `TestLoader_Load_Defaults_Applied` | Config mínimo verifica defaults |
| `TestLoader_Load_MissingFile` | Arquivo ausente retorna erro |
| `TestLoader_Load_ValidationError_MissingProjectName` | `project.name` obrigatório |
| `TestLoader_Load_ValidationError_WorkerMissingCommand` | `command` obrigatório em workers |
| `TestLoader_Load_ValidationError_InvalidStrategy` | Estratégia inválida rejeitada |
| `TestLoader_WatchSIGHUP_ReloadsConfig` | SIGHUP dispara recarga |

---

## Critérios atendidos

- [x] Struct Go definida com todas as seções suportadas (`project`, `workers`, `security`, `ipc`, `build`)
- [x] Config loader lê e valida `vyx.yaml` no startup, falhando rapidamente em erros
- [x] Config é recarregada no `SIGHUP` em modo desenvolvimento sem reiniciar o core
- [ ] `vyx new project` gera `vyx.yaml` padrão — pendente Issue #5 (CLI)

## Executar testes

```bash
cd core && go test ./infrastructure/config/... ./domain/config/...
```