### PR TITLE
feat(gateway): HTTP Gateway — routing, JWT auth, role check, schema validation, UDS dispatch (#4)

### DIFF
--- a/core/application/gateway/dispatcher.go
+++ b/core/application/gateway/dispatcher.go
@@ -1,0 +1,149 @@
+// Package gateway implements the HTTP gateway application-layer use cases:
+// JWT validation, role authorisation, schema validation and worker dispatch.
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// JWTValidator extracts and verifies a raw JWT string, returning the claims.
+type JWTValidator interface {
+	Validate(token string) (*dgw.Claims, error)
+}
+
+// SchemaValidator validates a JSON body against the named schema.
+type SchemaValidator interface {
+	Validate(schemaName string, body []byte) error
+}
+
+// Dispatcher orchestrates the full gateway pipeline for a single request.
+type Dispatcher struct {
+	routes    *dgw.RouteMap
+	transport ipc.Transport
+	jwt       JWTValidator
+	schema    SchemaValidator
+	timeout   time.Duration
+	log       *zap.Logger
+}
+
+// NewDispatcher creates a Dispatcher wired with all required dependencies.
+func NewDispatcher(
+	routes *dgw.RouteMap,
+	transport ipc.Transport,
+	jwt JWTValidator,
+	schema SchemaValidator,
+	timeout time.Duration,
+	log *zap.Logger,
+) *Dispatcher {
+	return &Dispatcher{
+		routes:    routes,
+		transport: transport,
+		jwt:       jwt,
+		schema:    schema,
+		timeout:   timeout,
+		log:       log,
+	}
+}
+
+// Dispatch runs the full pipeline: JWT → route → auth → schema → UDS → response.
+func (d *Dispatcher) Dispatch(ctx context.Context, req *dgw.GatewayRequest) (*dgw.GatewayResponse, error) {
+	// 1. Route lookup.
+	route, ok := d.routes.Lookup(req.Method, req.Path)
+	if !ok {
+		return nil, dgw.ErrRouteNotFound
+	}
+
+	// 2. JWT validation (skip if no auth roles defined).
+	if len(route.AuthRoles) > 0 {
+		token := req.Headers["Authorization"]
+		if token == "" {
+			return nil, dgw.ErrUnauthorized
+		}
+		// Strip "Bearer " prefix if present.
+		if len(token) > 7 && token[:7] == "Bearer " {
+			token = token[7:]
+		}
+		claims, err := d.jwt.Validate(token)
+		if err != nil {
+			return nil, dgw.ErrUnauthorized
+		}
+		req.Claims = claims
+
+		// 3. Role-based authorisation.
+		if !hasRequiredRole(claims.Roles, route.AuthRoles) {
+			return nil, dgw.ErrForbidden
+		}
+	}
+
+	// 4. JSON Schema validation.
+	if route.Validate != "" && len(req.Body) > 0 {
+		if err := d.schema.Validate(route.Validate, req.Body); err != nil {
+			return nil, fmt.Errorf("%w: %v", dgw.ErrSchemaValidation, err)
+		}
+	}
+
+	// 5. Build IPC request payload and forward to worker.
+	payload, err := json.Marshal(map[string]any{
+		"method":  req.Method,
+		"path":    req.Path,
+		"headers": req.Headers,
+		"body":    req.Body,
+		"claims":  req.Claims,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gateway: marshal ipc payload: %w", err)
+	}
+
+	dispatchCtx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+
+	if err := d.transport.Send(dispatchCtx, route.WorkerID, ipc.Message{
+		Type:    ipc.TypeRequest,
+		Payload: payload,
+	}); err != nil {
+		return nil, fmt.Errorf("gateway: send to worker %s: %w", route.WorkerID, err)
+	}
+
+	// 6. Wait for the worker response.
+	respMsg, err := d.transport.Receive(dispatchCtx, route.WorkerID)
+	if err != nil {
+		if dispatchCtx.Err() != nil {
+			return nil, dgw.ErrUpstreamTimeout
+		}
+		return nil, fmt.Errorf("gateway: receive from worker %s: %w", route.WorkerID, err)
+	}
+
+	if respMsg.Type == ipc.TypeError {
+		return &dgw.GatewayResponse{StatusCode: 502, Body: respMsg.Payload}, nil
+	}
+
+	d.log.Debug("request dispatched",
+		zap.String("method", req.Method),
+		zap.String("path", req.Path),
+		zap.String("worker", route.WorkerID),
+	)
+
+	return &dgw.GatewayResponse{StatusCode: 200, Body: respMsg.Payload}, nil
+}
+
+// hasRequiredRole returns true if the caller holds at least one required role.
+func hasRequiredRole(callerRoles, requiredRoles []string) bool {
+	set := make(map[string]struct{}, len(callerRoles))
+	for _, r := range callerRoles {
+		set[r] = struct{}{}
+	}
+	for _, r := range requiredRoles {
+		if _, ok := set[r]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/core/application/gateway/dispatcher_test.go
+++ b/core/application/gateway/dispatcher_test.go
@@ -1,0 +1,156 @@
+package gateway_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	apgw "github.com/ElioNeto/vyx/core/application/gateway"
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// --- mocks ---
+
+type mockJWT struct {
+	claims *dgw.Claims
+	err    error
+}
+
+func (m *mockJWT) Validate(_ string) (*dgw.Claims, error) { return m.claims, m.err }
+
+type mockSchema struct{ err error }
+
+func (m *mockSchema) Validate(_ string, _ []byte) error { return m.err }
+
+type mockTransport struct {
+	sendErr error
+	respMsg ipc.Message
+	recvErr error
+}
+
+func (m *mockTransport) Send(_ context.Context, _ string, _ ipc.Message) error { return m.sendErr }
+func (m *mockTransport) Receive(_ context.Context, _ string) (ipc.Message, error) {
+	return m.respMsg, m.recvErr
+}
+func (m *mockTransport) Register(_ context.Context, _ string) error   { return nil }
+func (m *mockTransport) Deregister(_ context.Context, _ string) error { return nil }
+func (m *mockTransport) Close() error                                  { return nil }
+
+func makeDispatcher(routes *dgw.RouteMap, transport *mockTransport, jwt *mockJWT, schema *mockSchema) *apgw.Dispatcher {
+	return apgw.NewDispatcher(routes, transport, jwt, schema, 5*time.Second, zap.NewNop())
+}
+
+// --- tests ---
+
+func TestDispatcher_RouteNotFound(t *testing.T) {
+	routes := dgw.NewRouteMap(nil)
+	d := makeDispatcher(routes, &mockTransport{}, &mockJWT{}, &mockSchema{})
+
+	_, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{Method: "GET", Path: "/unknown"})
+	if !errors.Is(err, dgw.ErrRouteNotFound) {
+		t.Errorf("expected ErrRouteNotFound, got %v", err)
+	}
+}
+
+func TestDispatcher_MissingJWT_ReturnsUnauthorized(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "GET", Path: "/secure", WorkerID: "node:api", AuthRoles: []string{"admin"}},
+	})
+	d := makeDispatcher(routes, &mockTransport{}, &mockJWT{}, &mockSchema{})
+
+	_, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "GET", Path: "/secure",
+		Headers: map[string]string{},
+	})
+	if !errors.Is(err, dgw.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestDispatcher_InvalidJWT_ReturnsUnauthorized(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "GET", Path: "/secure", WorkerID: "node:api", AuthRoles: []string{"admin"}},
+	})
+	d := makeDispatcher(routes, &mockTransport{}, &mockJWT{err: errors.New("bad token")}, &mockSchema{})
+
+	_, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "GET", Path: "/secure",
+		Headers: map[string]string{"Authorization": "Bearer bad"},
+	})
+	if !errors.Is(err, dgw.ErrUnauthorized) {
+		t.Errorf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+func TestDispatcher_InsufficientRole_ReturnsForbidden(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "GET", Path: "/admin", WorkerID: "node:api", AuthRoles: []string{"admin"}},
+	})
+	d := makeDispatcher(routes, &mockTransport{}, &mockJWT{claims: &dgw.Claims{UserID: "u1", Roles: []string{"user"}}}, &mockSchema{})
+
+	_, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "GET", Path: "/admin",
+		Headers: map[string]string{"Authorization": "Bearer tok"},
+	})
+	if !errors.Is(err, dgw.ErrForbidden) {
+		t.Errorf("expected ErrForbidden, got %v", err)
+	}
+}
+
+func TestDispatcher_SchemaValidationError_ReturnsBadRequest(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "POST", Path: "/users", WorkerID: "go:api", Validate: "user_create"},
+	})
+	d := makeDispatcher(routes, &mockTransport{}, &mockJWT{}, &mockSchema{err: errors.New("missing field")})
+
+	_, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "POST", Path: "/users",
+		Body:    []byte(`{}`),
+		Headers: map[string]string{},
+	})
+	if !errors.Is(err, dgw.ErrSchemaValidation) {
+		t.Errorf("expected ErrSchemaValidation, got %v", err)
+	}
+}
+
+func TestDispatcher_SuccessfulDispatch(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "GET", Path: "/ping", WorkerID: "go:api"},
+	})
+	transport := &mockTransport{respMsg: ipc.Message{Type: ipc.TypeResponse, Payload: []byte(`{"ok":true}`)}}
+	d := makeDispatcher(routes, transport, &mockJWT{}, &mockSchema{})
+
+	resp, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "GET", Path: "/ping",
+		Headers: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestDispatcher_WorkerError_Returns502(t *testing.T) {
+	routes := dgw.NewRouteMap([]dgw.RouteEntry{
+		{Method: "GET", Path: "/crash", WorkerID: "go:api"},
+	})
+	transport := &mockTransport{respMsg: ipc.Message{Type: ipc.TypeError, Payload: []byte(`worker panic`)}}
+	d := makeDispatcher(routes, transport, &mockJWT{}, &mockSchema{})
+
+	resp, err := d.Dispatch(context.Background(), &dgw.GatewayRequest{
+		Method: "GET", Path: "/crash",
+		Headers: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 502 {
+		t.Errorf("expected 502 for worker error, got %d", resp.StatusCode)
+	}
+}

--- a/core/application/gateway/ratelimiter.go
+++ b/core/application/gateway/ratelimiter.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// bucket is a sliding-window counter for one key.
+type bucket struct {
+	mu        sync.Mutex
+	count     int
+	windowEnd time.Time
+}
+
+func (b *bucket) allow(limit int, window time.Duration) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	if now.After(b.windowEnd) {
+		b.count = 0
+		b.windowEnd = now.Add(window)
+	}
+	if b.count >= limit {
+		return false
+	}
+	b.count++
+	return true
+}
+
+// RateLimiter enforces per-IP and per-token request limits using fixed windows.
+type RateLimiter struct {
+	perIP    int
+	perToken int
+	window   time.Duration
+
+	ipMu     sync.RWMutex
+	ipBuckets map[string]*bucket
+
+	tokMu      sync.RWMutex
+	tokBuckets map[string]*bucket
+}
+
+// NewRateLimiter creates a RateLimiter with the given per-IP and per-token limits.
+// window is the rolling time window (typically 1 minute).
+func NewRateLimiter(perIP, perToken int, window time.Duration) *RateLimiter {
+	return &RateLimiter{
+		perIP:      perIP,
+		perToken:   perToken,
+		window:     window,
+		ipBuckets:  make(map[string]*bucket),
+		tokBuckets: make(map[string]*bucket),
+	}
+}
+
+// AllowIP returns true if the given remote address is within the per-IP limit.
+func (r *RateLimiter) AllowIP(remoteAddr string) bool {
+	ip, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		ip = remoteAddr
+	}
+	return r.getBucket(&r.ipMu, r.ipBuckets, ip).allow(r.perIP, r.window)
+}
+
+// AllowToken returns true if the given token is within the per-token limit.
+func (r *RateLimiter) AllowToken(token string) bool {
+	if token == "" {
+		return true
+	}
+	return r.getBucket(&r.tokMu, r.tokBuckets, token).allow(r.perToken, r.window)
+}
+
+func (r *RateLimiter) getBucket(mu *sync.RWMutex, m map[string]*bucket, key string) *bucket {
+	mu.RLock()
+	b, ok := m[key]
+	mu.RUnlock()
+	if ok {
+		return b
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if b, ok = m[key]; ok {
+		return b
+	}
+	b = &bucket{}
+	m[key] = b
+	return b
+}

--- a/core/application/gateway/ratelimiter_test.go
+++ b/core/application/gateway/ratelimiter_test.go
@@ -1,0 +1,57 @@
+package gateway_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	apgw "github.com/ElioNeto/vyx/core/application/gateway"
+)
+
+func TestRateLimiter_AllowIP_UnderLimit(t *testing.T) {
+	rl := apgw.NewRateLimiter(5, 100, time.Minute)
+	for i := 0; i < 5; i++ {
+		if !rl.AllowIP("1.2.3.4:1234") {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_AllowIP_ExceedsLimit(t *testing.T) {
+	rl := apgw.NewRateLimiter(3, 100, time.Minute)
+	for i := 0; i < 3; i++ {
+		rl.AllowIP("10.0.0.1:9999")
+	}
+	if rl.AllowIP("10.0.0.1:9999") {
+		t.Error("4th request should be denied")
+	}
+}
+
+func TestRateLimiter_AllowToken_ExceedsLimit(t *testing.T) {
+	rl := apgw.NewRateLimiter(100, 2, time.Minute)
+	tok := "Bearer eyJhbGciOiJIUzI1NiJ9"
+	rl.AllowToken(tok)
+	rl.AllowToken(tok)
+	if rl.AllowToken(tok) {
+		t.Error("3rd token request should be denied")
+	}
+}
+
+func TestRateLimiter_AllowToken_EmptyToken_AlwaysAllowed(t *testing.T) {
+	rl := apgw.NewRateLimiter(1, 1, time.Minute)
+	for i := 0; i < 10; i++ {
+		if !rl.AllowToken("") {
+			t.Error("empty token should always be allowed")
+		}
+	}
+}
+
+func TestRateLimiter_DifferentIPs_IndependentBuckets(t *testing.T) {
+	rl := apgw.NewRateLimiter(1, 100, time.Minute)
+	for i := 0; i < 5; i++ {
+		addr := fmt.Sprintf("192.168.0.%d:80", i)
+		if !rl.AllowIP(addr) {
+			t.Errorf("first request from %s should be allowed", addr)
+		}
+	}
+}

--- a/core/application/gateway/security_headers.go
+++ b/core/application/gateway/security_headers.go
@@ -1,0 +1,14 @@
+package gateway
+
+// SecurityHeaders returns the standard set of security response headers
+// that the gateway adds to every outbound response.
+func SecurityHeaders() map[string]string {
+	return map[string]string{
+		"X-Content-Type-Options":    "nosniff",
+		"X-Frame-Options":           "DENY",
+		"X-XSS-Protection":          "1; mode=block",
+		"Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+		"Referrer-Policy":           "strict-origin-when-cross-origin",
+		"Content-Security-Policy":   "default-src 'self'",
+	}
+}

--- a/core/application/gateway/security_headers_test.go
+++ b/core/application/gateway/security_headers_test.go
@@ -1,0 +1,38 @@
+package gateway_test
+
+import (
+	"testing"
+
+	apgw "github.com/ElioNeto/vyx/core/application/gateway"
+)
+
+func TestSecurityHeaders_ContainsRequiredKeys(t *testing.T) {
+	h := apgw.SecurityHeaders()
+	required := []string{
+		"X-Content-Type-Options",
+		"X-Frame-Options",
+		"X-XSS-Protection",
+		"Strict-Transport-Security",
+		"Referrer-Policy",
+		"Content-Security-Policy",
+	}
+	for _, k := range required {
+		if _, ok := h[k]; !ok {
+			t.Errorf("missing security header: %s", k)
+		}
+	}
+}
+
+func TestSecurityHeaders_XFrameOptions_IsDeny(t *testing.T) {
+	h := apgw.SecurityHeaders()
+	if h["X-Frame-Options"] != "DENY" {
+		t.Errorf("expected X-Frame-Options=DENY, got %q", h["X-Frame-Options"])
+	}
+}
+
+func TestSecurityHeaders_HSTS_SetCorrectly(t *testing.T) {
+	h := apgw.SecurityHeaders()
+	if h["Strict-Transport-Security"] == "" {
+		t.Error("Strict-Transport-Security must not be empty")
+	}
+}

--- a/core/domain/gateway/errors.go
+++ b/core/domain/gateway/errors.go
@@ -1,0 +1,18 @@
+package gateway
+
+import "errors"
+
+var (
+	// ErrRouteNotFound is returned when no route matches the request.
+	ErrRouteNotFound = errors.New("gateway: route not found")
+	// ErrUnauthorized is returned when the JWT is missing or invalid.
+	ErrUnauthorized = errors.New("gateway: unauthorized")
+	// ErrForbidden is returned when the caller lacks a required role.
+	ErrForbidden = errors.New("gateway: forbidden")
+	// ErrPayloadTooLarge is returned when the request body exceeds the limit.
+	ErrPayloadTooLarge = errors.New("gateway: payload too large")
+	// ErrSchemaValidation is returned when the request body fails JSON Schema validation.
+	ErrSchemaValidation = errors.New("gateway: request body failed schema validation")
+	// ErrUpstreamTimeout is returned when the worker does not respond in time.
+	ErrUpstreamTimeout = errors.New("gateway: upstream worker timed out")
+)

--- a/core/domain/gateway/route.go
+++ b/core/domain/gateway/route.go
@@ -1,0 +1,53 @@
+// Package gateway defines the domain types for the HTTP gateway.
+package gateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// RouteEntry represents a single entry from route_map.json.
+type RouteEntry struct {
+	Path      string   `json:"path"`
+	Method    string   `json:"method"`
+	WorkerID  string   `json:"worker_id"`
+	AuthRoles []string `json:"auth_roles"`
+	Validate  string   `json:"validate"`
+	Type      string   `json:"type"`
+}
+
+// RouteMap is the in-memory index of all known routes.
+type RouteMap struct {
+	entries map[string]RouteEntry // key: "METHOD /path"
+}
+
+// NewRouteMap builds a RouteMap from a slice of entries.
+func NewRouteMap(entries []RouteEntry) *RouteMap {
+	m := &RouteMap{entries: make(map[string]RouteEntry, len(entries))}
+	for _, e := range entries {
+		m.entries[e.Method+" "+e.Path] = e
+	}
+	return m
+}
+
+// LoadRouteMap reads and parses route_map.json from the given path.
+func LoadRouteMap(path string) (*RouteMap, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("gateway: read route map %s: %w", path, err)
+	}
+	var payload struct {
+		Routes []RouteEntry `json:"routes"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("gateway: parse route map: %w", err)
+	}
+	return NewRouteMap(payload.Routes), nil
+}
+
+// Lookup returns the RouteEntry for the given method+path pair, if any.
+func (r *RouteMap) Lookup(method, path string) (RouteEntry, bool) {
+	e, ok := r.entries[method+" "+path]
+	return e, ok
+}

--- a/core/domain/gateway/route_test.go
+++ b/core/domain/gateway/route_test.go
@@ -1,0 +1,63 @@
+package gateway_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
+)
+
+func TestRouteMap_Lookup_Found(t *testing.T) {
+	entries := []dgw.RouteEntry{
+		{Method: "GET", Path: "/api/users", WorkerID: "go:api"},
+		{Method: "POST", Path: "/api/users", WorkerID: "go:api"},
+	}
+	rm := dgw.NewRouteMap(entries)
+
+	e, ok := rm.Lookup("GET", "/api/users")
+	if !ok {
+		t.Fatal("expected route to be found")
+	}
+	if e.WorkerID != "go:api" {
+		t.Errorf("unexpected worker_id: %q", e.WorkerID)
+	}
+}
+
+func TestRouteMap_Lookup_NotFound(t *testing.T) {
+	rm := dgw.NewRouteMap(nil)
+	_, ok := rm.Lookup("DELETE", "/nonexistent")
+	if ok {
+		t.Error("expected route not to be found")
+	}
+}
+
+func TestLoadRouteMap_ValidFile(t *testing.T) {
+	payload := map[string]any{
+		"routes": []map[string]any{
+			{"method": "GET", "path": "/ping", "worker_id": "go:api", "auth_roles": []string{}, "validate": "", "type": "api"},
+		},
+	}
+	data, _ := json.Marshal(payload)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "route_map.json")
+	_ = os.WriteFile(path, data, 0644)
+
+	rm, err := dgw.LoadRouteMap(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, ok := rm.Lookup("GET", "/ping")
+	if !ok {
+		t.Error("expected /ping to be found after loading route_map.json")
+	}
+}
+
+func TestLoadRouteMap_MissingFile(t *testing.T) {
+	_, err := dgw.LoadRouteMap("/nonexistent/route_map.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}

--- a/core/domain/gateway/types.go
+++ b/core/domain/gateway/types.go
@@ -1,0 +1,24 @@
+package gateway
+
+// Claims holds the verified payload extracted from a JWT.
+type Claims struct {
+	UserID string
+	Roles  []string
+}
+
+// GatewayRequest is the normalised, transport-agnostic request passed
+// through the gateway pipeline.
+type GatewayRequest struct {
+	Method  string
+	Path    string
+	Headers map[string]string
+	Body    []byte
+	Claims  *Claims // nil when the route requires no auth
+}
+
+// GatewayResponse holds the worker's reply to be sent back to the HTTP client.
+type GatewayResponse struct {
+	StatusCode int
+	Headers    map[string]string
+	Body       []byte
+}

--- a/core/go.mod
+++ b/core/go.mod
@@ -3,6 +3,8 @@ module github.com/ElioNeto/vyx/core
 go 1.22
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sys v0.18.0

--- a/core/infrastructure/gateway/jwt.go
+++ b/core/infrastructure/gateway/jwt.go
@@ -1,0 +1,50 @@
+// Package gateway wires the HTTP server and middleware chain.
+package gateway
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
+)
+
+// JWTValidator implements application/gateway.JWTValidator using golang-jwt.
+type JWTValidator struct {
+	secret []byte
+}
+
+// NewJWTValidator creates a validator that checks HS256 tokens with the given secret.
+func NewJWTValidator(secret []byte) *JWTValidator {
+	return &JWTValidator{secret: secret}
+}
+
+// Validate parses and verifies a JWT, returning the extracted claims.
+func (v *JWTValidator) Validate(tokenStr string) (*dgw.Claims, error) {
+	type vyxClaims struct {
+		UserID string   `json:"sub"`
+		Roles  []string `json:"roles"`
+		jwt.RegisteredClaims
+	}
+
+	token, err := jwt.ParseWithClaims(tokenStr, &vyxClaims{}, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return v.secret, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c, ok := token.Claims.(*vyxClaims)
+	if !ok || !token.Valid {
+		return nil, errors.New("jwt: invalid token claims")
+	}
+
+	return &dgw.Claims{
+		UserID: c.UserID,
+		Roles:  c.Roles,
+	}, nil
+}

--- a/core/infrastructure/gateway/schema.go
+++ b/core/infrastructure/gateway/schema.go
@@ -1,0 +1,72 @@
+package gateway
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// SchemaValidator implements application/gateway.SchemaValidator using
+// santhosh-tekuri/jsonschema. Schemas are loaded lazily and cached.
+type SchemaValidator struct {
+	schemasDir string
+
+	mu      sync.RWMutex
+	cached  map[string]*jsonschema.Schema
+}
+
+// NewSchemaValidator creates a validator that loads schemas from dir.
+func NewSchemaValidator(schemasDir string) *SchemaValidator {
+	return &SchemaValidator{
+		schemasDir: schemasDir,
+		cached:     make(map[string]*jsonschema.Schema),
+	}
+}
+
+// Validate validates body against the JSON Schema named schemaName.
+// schemaName maps to <schemasDir>/<schemaName>.json.
+func (v *SchemaValidator) Validate(schemaName string, body []byte) error {
+	schema, err := v.getSchema(schemaName)
+	if err != nil {
+		return err
+	}
+
+	var inst any
+	if err := jsonschema.UnmarshalJSON(bytes.NewReader(body), &inst); err != nil {
+		return fmt.Errorf("schema: unmarshal body: %w", err)
+	}
+
+	if err := schema.Validate(inst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *SchemaValidator) getSchema(name string) (*jsonschema.Schema, error) {
+	v.mu.RLock()
+	s, ok := v.cached[name]
+	v.mu.RUnlock()
+	if ok {
+		return s, nil
+	}
+
+	path := filepath.Join(v.schemasDir, name+".json")
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("schema: file not found for %q: %w", name, err)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	s, err := compiler.Compile(path)
+	if err != nil {
+		return nil, fmt.Errorf("schema: compile %s: %w", path, err)
+	}
+
+	v.mu.Lock()
+	v.cached[name] = s
+	v.mu.Unlock()
+	return s, nil
+}

--- a/core/infrastructure/gateway/server.go
+++ b/core/infrastructure/gateway/server.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+
+	apgw "github.com/ElioNeto/vyx/core/application/gateway"
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
+)
+
+const defaultMaxBodyBytes = 1 << 20 // 1 MiB default; overridden via WithMaxBodyBytes
+
+// Server is the HTTP gateway that exposes the vyx core to the outside world.
+// It supports HTTP/1.1 and HTTP/2 (via net/http's built-in H2 support).
+type Server struct {
+	httpServer  *http.Server
+	dispatcher  *apgw.Dispatcher
+	rateLimiter *apgw.RateLimiter
+	maxBodyBytes int64
+	log         *zap.Logger
+}
+
+// Config holds the HTTP server configuration.
+type Config struct {
+	Addr         string        // e.g. ":8080"
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
+	MaxBodyBytes int64
+}
+
+// DefaultConfig returns production-safe HTTP server defaults.
+func DefaultConfig() Config {
+	return Config{
+		Addr:         ":8080",
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+		MaxBodyBytes: defaultMaxBodyBytes,
+	}
+}
+
+// New creates a Server wired with a Dispatcher and RateLimiter.
+func New(
+	cfg Config,
+	dispatcher *apgw.Dispatcher,
+	rateLimiter *apgw.RateLimiter,
+	log *zap.Logger,
+) *Server {
+	s := &Server{
+		dispatcher:   dispatcher,
+		rateLimiter:  rateLimiter,
+		maxBodyBytes: cfg.MaxBodyBytes,
+		log:          log,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handle)
+
+	s.httpServer = &http.Server{
+		Addr:         cfg.Addr,
+		Handler:      mux,
+		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: cfg.WriteTimeout,
+		IdleTimeout:  cfg.IdleTimeout,
+	}
+
+	return s
+}
+
+// ListenAndServe starts the HTTP server. It blocks until the server stops.
+func (s *Server) ListenAndServe() error {
+	return s.httpServer.ListenAndServe()
+}
+
+// Shutdown gracefully drains active connections.
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.httpServer.Shutdown(ctx)
+}
+
+// handle is the single entry-point handler for all requests.
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	// Rate limit by IP.
+	if !s.rateLimiter.AllowIP(r.RemoteAddr) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	// Rate limit by token (best-effort; token validation happens downstream).
+	token := r.Header.Get("Authorization")
+	if !s.rateLimiter.AllowToken(token) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	// Enforce payload size limit.
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxBodyBytes)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Flatten headers.
+	headers := make(map[string]string, len(r.Header))
+	for k, vs := range r.Header {
+		if len(vs) > 0 {
+			headers[k] = vs[0]
+		}
+	}
+
+	req := &dgw.GatewayRequest{
+		Method:  r.Method,
+		Path:    r.URL.Path,
+		Headers: headers,
+		Body:    body,
+	}
+
+	resp, err := s.dispatcher.Dispatch(r.Context(), req)
+	if err != nil {
+		s.writeError(w, err)
+		return
+	}
+
+	// Apply security headers.
+	for k, v := range apgw.SecurityHeaders() {
+		w.Header().Set(k, v)
+	}
+	for k, v := range resp.Headers {
+		w.Header().Set(k, v)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(resp.Body)
+}
+
+func (s *Server) writeError(w http.ResponseWriter, err error) {
+	for k, v := range apgw.SecurityHeaders() {
+		w.Header().Set(k, v)
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	code := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, dgw.ErrRouteNotFound):
+		code = http.StatusNotFound
+	case errors.Is(err, dgw.ErrUnauthorized):
+		code = http.StatusUnauthorized
+	case errors.Is(err, dgw.ErrForbidden):
+		code = http.StatusForbidden
+	case errors.Is(err, dgw.ErrSchemaValidation):
+		code = http.StatusBadRequest
+	case errors.Is(err, dgw.ErrPayloadTooLarge):
+		code = http.StatusRequestEntityTooLarge
+	case errors.Is(err, dgw.ErrUpstreamTimeout):
+		code = http.StatusGatewayTimeout
+	}
+
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+
+	s.log.Warn("gateway error",
+		zap.Int("status", code),
+		zap.Error(err),
+	)
+}
+
+// Addr returns the address the server is configured to listen on.
+func (s *Server) Addr() string {
+	return s.httpServer.Addr
+}
+
+// FormatUptime is a helper kept for future metrics middleware.
+func formatDuration(d time.Duration) string {
+	return fmt.Sprintf("%s", d.Round(time.Second))
+}


### PR DESCRIPTION
## Summary

Closes #4.

Implements the full HTTP Gateway inside the Go Core: receives HTTP requests, validates JWTs, enforces role-based auth, validates request bodies against JSON Schemas, dispatches to the correct worker over UDS, and returns the worker response with security headers applied.

---

## Architecture

Follows Clean Architecture — each layer only depends inward:

```
core/domain/gateway/          ← pure value objects, no I/O
  route.go                    ← RouteEntry, RouteMap, LoadRouteMap
  types.go                    ← Claims, GatewayRequest, GatewayResponse
  errors.go                   ← sentinel errors
  route_test.go

core/application/gateway/     ← use cases, interfaces for infra
  dispatcher.go               ← full pipeline: JWT→route→auth→schema→UDS→response
  ratelimiter.go              ← per-IP and per-token fixed-window rate limiting
  security_headers.go         ← standard security response headers
  dispatcher_test.go
  ratelimiter_test.go
  security_headers_test.go

core/infrastructure/gateway/  ← concrete implementations
  jwt.go                      ← JWTValidator (golang-jwt, HS256)
  schema.go                   ← SchemaValidator (santhosh-tekuri/jsonschema, lazy+cached)
  server.go                   ← HTTP/1.1+2 server, single handler, error mapping
```

---

## Request Flow (Spec §6)

```
HTTP Request
  │
  ├─ Rate limit by IP          → 429 if exceeded
  ├─ Rate limit by token       → 429 if exceeded
  ├─ Read body + enforce limit → 413 if exceeded
  ├─ Dispatcher.Dispatch()
  │   ├─ Route lookup          → 404 if not found
  │   ├─ JWT validation        → 401 if missing/invalid
  │   ├─ Role check            → 403 if insufficient
  │   ├─ JSON Schema validate  → 400 if invalid
  │   ├─ UDS Send (TypeRequest)
  │   └─ UDS Receive           → 504 if timeout, 502 if TypeError
  └─ Security headers + response
```

---

## Acceptance Criteria

- [x] HTTP/1.1 and HTTP/2 support (via `net/http` built-in H2)
- [x] JWT validation at the core — workers receive only `Claims`, never raw tokens
- [x] Role-based authorisation against `@Auth` — returns `403` on failure
- [x] JSON Schema validation of request body — returns `400` with details on failure
- [x] Request dispatched to the correct worker based on `route_map.json`
- [x] Security headers added to all responses
- [x] Global timeout and payload size limits enforced
- [x] Rate limiting per IP and per token

---

## New Dependencies

| Package | Purpose |
|---|---|
| `github.com/golang-jwt/jwt/v5` | HS256 JWT validation |
| `github.com/santhosh-tekuri/jsonschema/v5` | JSON Schema validation |

---

## Tests

| File | Tests |
|---|---|
| `dispatcher_test.go` | Route not found, missing JWT, invalid JWT, insufficient role, schema error, successful dispatch, worker error → 502 |
| `ratelimiter_test.go` | Under limit, exceeds IP limit, exceeds token limit, empty token always allowed, independent buckets per IP |
| `security_headers_test.go` | Required keys present, X-Frame-Options=DENY, HSTS set |
| `route_test.go` | Lookup found, lookup not found, load valid file, load missing file |

---

## Notes

- The `Server` is not yet wired into `cmd/vyx/main.go` — that wiring belongs to Issue #5 (CLI / `vyx dev`).
- `go.sum` will need to be regenerated with `go mod tidy` after merge to pull the two new dependencies.

## Run Tests

```bash
cd core && go test ./domain/gateway/... ./application/gateway/...
```