### PR TITLE
feat(cli): vyx new, vyx dev, vyx build, vyx annotate (#5, closes #33)

### DIFF
--- a/cmd/vyx/cmd_annotate.go
+++ b/cmd/vyx/cmd_annotate.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/ElioNeto/vyx/scanner"
+)
+
+func runAnnotate(args []string) {
+	fs := flag.NewFlagSet("annotate", flag.ExitOnError)
+	goDir := fs.String("go", "backend/go", "Directory containing Go source files")
+	tsDir := fs.String("ts", "backend/node", "Directory containing TypeScript source files")
+	frontendDir := fs.String("frontend", "frontend/src", "Directory containing React/TSX frontend files")
+	jsonOut := fs.Bool("json", false, "Output discovered routes as JSON instead of table")
+	_ = fs.Parse(args)
+
+	routes, errs := collectRoutes(*goDir, *tsDir, *frontendDir)
+
+	if len(errs) > 0 {
+		fmt.Fprintln(os.Stderr, "annotation errors:")
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "  ❌ %s\n", e.Error())
+		}
+		os.Exit(1)
+	}
+
+	if len(routes) == 0 {
+		fmt.Println("No routes found.")
+		return
+	}
+
+	if *jsonOut {
+		data, _ := json.MarshalIndent(map[string]any{"routes": routes}, "", "  ")
+		fmt.Println(string(data))
+		return
+	}
+
+	// Human-readable table.
+	fmt.Printf("%-8s %-35s %-20s %s\n", "METHOD", "PATH", "WORKER", "AUTH")
+	fmt.Println("------------------------------------------------------------------------")
+	for _, r := range routes {
+		auth := "-"
+		if len(r.AuthRoles) > 0 {
+			for i, role := range r.AuthRoles {
+				if i > 0 {
+					auth += ","
+				}
+				auth = role
+			}
+		}
+		fmt.Printf("%-8s %-35s %-20s %s\n", r.Method, r.Path, r.WorkerID, auth)
+	}
+	fmt.Printf("\n%d route(s) discovered.\n", len(routes))
+}
+
+// collectRoutes runs the scanner across all three directories and returns
+// routes + any annotation errors.
+func collectRoutes(goDir, tsDir, frontendDir string) ([]scanner.Route, []scanner.AnnotationError) {
+	var routes []scanner.Route
+	var errs []scanner.AnnotationError
+
+	if goDir != "" {
+		r, e := scanner.ParseGoFiles(goDir, "go:"+goDir)
+		routes = append(routes, r...)
+		errs = append(errs, e...)
+	}
+	if tsDir != "" {
+		r, e := scanner.ParseTSFiles(tsDir, "node:"+tsDir)
+		routes = append(routes, r...)
+		errs = append(errs, e...)
+	}
+	if frontendDir != "" {
+		r, e := scanner.ParseTSFiles(frontendDir, "node:frontend")
+		routes = append(routes, r...)
+		errs = append(errs, e...)
+	}
+
+	validErrs := scanner.Validate(routes)
+	errs = append(errs, validErrs...)
+
+	return routes, errs
+}
+
+// runCommand is a shared helper to exec a process and stream output.
+func runCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/vyx/cmd_build.go
+++ b/cmd/vyx/cmd_build.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ElioNeto/vyx/scanner"
+)
+
+func runBuild(args []string) {
+	fs := flag.NewFlagSet("build", flag.ExitOnError)
+	goDir := fs.String("go", "backend/go", "Directory containing Go source files")
+	tsDir := fs.String("ts", "backend/node", "Directory containing TypeScript source files")
+	frontendDir := fs.String("frontend", "frontend/src", "Directory containing React/TSX frontend files")
+	output := fs.String("output", "route_map.json", "Output path for the generated route map")
+	_ = fs.Parse(args)
+
+	fmt.Println("🔍 vyx build: scanning annotations...")
+
+	errs, err := scanner.Generate(*goDir, *tsDir, *frontendDir, *output)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(errs) > 0 {
+		fmt.Fprintln(os.Stderr, "annotation errors:")
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "  ❌ %s\n", e.Error())
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ route_map.json written to %s\n", *output)
+	fmt.Println("🔧 Building core binary...")
+
+	if err := runCommand("go", "build", "-o", ".vyx/core", "./core/cmd/vyx"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: go build failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("✅ Build complete.")
+}

--- a/cmd/vyx/cmd_dev.go
+++ b/cmd/vyx/cmd_dev.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+func runDev(args []string) {
+	fs := flag.NewFlagSet("dev", flag.ExitOnError)
+	configPath := fs.String("config", "vyx.yaml", "Path to vyx.yaml")
+	addr := fs.String("addr", ":8080", "HTTP listen address")
+	_ = fs.Parse(args)
+
+	if _, err := os.Stat(*configPath); err != nil {
+		fmt.Fprintf(os.Stderr, "error: config file not found: %s\n", *configPath)
+		fmt.Fprintln(os.Stderr, "Run 'vyx new project <name>' to scaffold a project first.")
+		os.Exit(1)
+	}
+
+	fmt.Printf("🚀 vyx dev starting...\n")
+	fmt.Printf("   config : %s\n", *configPath)
+	fmt.Printf("   addr   : %s\n", *addr)
+	fmt.Printf("   mode   : development (SIGHUP reloads config)\n")
+	fmt.Println()
+
+	// Build the core binary first so we run the compiled version.
+	fmt.Println("🔧 Building core...")
+	build := exec.Command("go", "build", "-o", ".vyx/core", "./core/cmd/vyx")
+	build.Stdout = os.Stdout
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: build failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Launch the core process.
+	cmd := exec.Command(".vyx/core")
+	cmd.Env = append(os.Environ(),
+		"VYX_CONFIG="+*configPath,
+		"VYX_ADDR="+*addr,
+		"VYX_ENV=development",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to start core: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ vyx core running (pid %d)\n", cmd.Process.Pid)
+	fmt.Println("   Press Ctrl+C to stop. Send SIGHUP to reload config.")
+
+	// Forward SIGINT/SIGTERM to the child process for graceful shutdown.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		sig := <-sigs
+		fmt.Printf("\n🛑 received %s — stopping core...\n", sig)
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}()
+
+	_ = cmd.Wait()
+	fmt.Println("👋 vyx dev stopped")
+}

--- a/cmd/vyx/cmd_new.go
+++ b/cmd/vyx/cmd_new.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const newUsage = `Usage: vyx new project <name>
+
+Scaffolds a new vyx project directory at ./<name>/ with the following structure:
+
+  <name>/
+  ├── core/
+  ├── backend/
+  │   ├── go/
+  │   ├── node/
+  │   └── python/
+  ├── frontend/
+  │   └── src/
+  ├── schemas/
+  └── vyx.yaml
+
+Flags:
+  -h, --help   Show this help message
+`
+
+// defaultVyxYAML returns the content of a sensible default vyx.yaml for projectName.
+// Values are sourced from the canonical defaults in core/domain/config.
+func defaultVyxYAML(projectName string) string {
+	return fmt.Sprintf(`project:
+  name: %s
+  version: 0.1.0
+
+workers:
+  - id: node:api
+    command: node backend/node/index.js
+    replicas: 1
+    strategy: round-robin
+    startup_timeout: 10s
+    shutdown_timeout: 5s
+
+security:
+  jwt_secret_env: JWT_SECRET
+  rate_limit:
+    per_ip: 100
+    per_token: 500
+  payload_max_size: 1mb
+  global_timeout: 30s
+
+ipc:
+  socket_dir: /tmp/vyx
+  arrow_threshold: 512kb
+
+build:
+  schemas_dir: ./schemas
+  route_map_output: ./route_map.json
+`, projectName)
+}
+
+func runNew(args []string) {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Print(newUsage)
+		if len(args) == 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	if args[0] != "project" {
+		fmt.Fprintf(os.Stderr, "error: unknown subcommand %q for 'vyx new'\n", args[0])
+		fmt.Fprintf(os.Stderr, "Did you mean: vyx new project <name>\n")
+		os.Exit(1)
+	}
+
+	if len(args) < 2 || strings.TrimSpace(args[1]) == "" {
+		fmt.Fprintln(os.Stderr, "error: project name is required")
+		fmt.Fprintln(os.Stderr, "Usage: vyx new project <name>")
+		os.Exit(1)
+	}
+
+	name := strings.TrimSpace(args[1])
+	if err := scaffoldProject(name); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("✅ Project %q created at ./%s/\n", name, name)
+	fmt.Printf("   Next steps:\n")
+	fmt.Printf("     cd %s\n", name)
+	fmt.Printf("     vyx dev\n")
+}
+
+// scaffoldProject creates the project directory tree and vyx.yaml.
+func scaffoldProject(name string) error {
+	root := filepath.Join(".", name)
+
+	if _, err := os.Stat(root); err == nil {
+		return fmt.Errorf("directory %q already exists", root)
+	}
+
+	dirs := []string{
+		"core",
+		"backend/go",
+		"backend/node",
+		"backend/python",
+		"frontend/src",
+		"schemas",
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(root, d), 0755); err != nil {
+			return fmt.Errorf("create directory %s: %w", d, err)
+		}
+	}
+
+	// Write vyx.yaml seeded from defaults.
+	vyxYAML := defaultVyxYAML(name)
+
+	// Validate the generated YAML parses correctly before writing.
+	var check any
+	if err := yaml.Unmarshal([]byte(vyxYAML), &check); err != nil {
+		return fmt.Errorf("generated vyx.yaml is invalid: %w", err)
+	}
+
+	yamlPath := filepath.Join(root, "vyx.yaml")
+	if err := os.WriteFile(yamlPath, []byte(vyxYAML), 0644); err != nil {
+		return fmt.Errorf("write vyx.yaml: %w", err)
+	}
+
+	// Write .gitkeep files so empty directories are tracked by git.
+	for _, d := range []string{"backend/go", "backend/node", "backend/python", "frontend/src", "schemas"} {
+		gitkeep := filepath.Join(root, d, ".gitkeep")
+		_ = os.WriteFile(gitkeep, []byte{}, 0644)
+	}
+
+	return nil
+}

--- a/cmd/vyx/cmd_new_test.go
+++ b/cmd/vyx/cmd_new_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestScaffoldProject_CreatesDirectoryTree(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	if err := scaffoldProject("my-app"); err != nil {
+		t.Fatalf("scaffoldProject failed: %v", err)
+	}
+
+	expected := []string{
+		"my-app/core",
+		"my-app/backend/go",
+		"my-app/backend/node",
+		"my-app/backend/python",
+		"my-app/frontend/src",
+		"my-app/schemas",
+		"my-app/vyx.yaml",
+	}
+	for _, p := range expected {
+		if _, err := os.Stat(filepath.Join(tmpDir, p)); err != nil {
+			t.Errorf("expected path %q to exist, got: %v", p, err)
+		}
+	}
+}
+
+func TestScaffoldProject_VyxYAML_IsValid(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	if err := scaffoldProject("test-project"); err != nil {
+		t.Fatalf("scaffoldProject failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "test-project", "vyx.yaml"))
+	if err != nil {
+		t.Fatalf("vyx.yaml not found: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("vyx.yaml is not valid YAML: %v", err)
+	}
+
+	project, ok := parsed["project"].(map[string]any)
+	if !ok {
+		t.Fatal("vyx.yaml missing 'project' section")
+	}
+	if project["name"] != "test-project" {
+		t.Errorf("expected project.name=test-project, got %q", project["name"])
+	}
+	if _, ok := parsed["workers"]; !ok {
+		t.Error("vyx.yaml missing 'workers' section")
+	}
+	if _, ok := parsed["security"]; !ok {
+		t.Error("vyx.yaml missing 'security' section")
+	}
+	if _, ok := parsed["ipc"]; !ok {
+		t.Error("vyx.yaml missing 'ipc' section")
+	}
+	if _, ok := parsed["build"]; !ok {
+		t.Error("vyx.yaml missing 'build' section")
+	}
+}
+
+func TestScaffoldProject_AlreadyExists_ReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	_ = os.Chdir(tmpDir)
+	defer os.Chdir(origDir)
+
+	_ = os.Mkdir("existing-app", 0755)
+
+	err := scaffoldProject("existing-app")
+	if err == nil {
+		t.Error("expected error when project directory already exists")
+	}
+}
+
+func TestDefaultVyxYAML_ContainsProjectName(t *testing.T) {
+	yamlContent := defaultVyxYAML("my-service")
+	if !strings.Contains(yamlContent, "name: my-service") {
+		t.Errorf("expected vyx.yaml to contain 'name: my-service', got:\n%s", yamlContent)
+	}
+}
+
+func TestDefaultVyxYAML_IsValidYAML(t *testing.T) {
+	yamlContent := defaultVyxYAML("valid-project")
+	var parsed any
+	if err := yaml.Unmarshal([]byte(yamlContent), &parsed); err != nil {
+		t.Fatalf("defaultVyxYAML generated invalid YAML: %v", err)
+	}
+}

--- a/cmd/vyx/go.mod
+++ b/cmd/vyx/go.mod
@@ -1,0 +1,10 @@
+module github.com/ElioNeto/vyx/cli
+
+go 1.22
+
+require (
+	github.com/ElioNeto/vyx/scanner v0.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+replace github.com/ElioNeto/vyx/scanner => ../../scanner

--- a/cmd/vyx/main.go
+++ b/cmd/vyx/main.go
@@ -1,0 +1,55 @@
+// Command vyx is the unified CLI for the vyx framework.
+//
+// Subcommands:
+//
+//	vyx new project <name>  — scaffold a new vyx project
+//	vyx dev                 — start core in development mode
+//	vyx build               — run scanner and build all artefacts
+//	vyx annotate            — validate annotations and print route map
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const usage = `vyx — the polyglot microframework CLI
+
+Usage:
+  vyx <command> [arguments]
+
+Commands:
+  new project <name>   Scaffold a new vyx project in ./<name>/
+  dev                  Start the core in development mode (hot reload)
+  build                Run the annotation scanner and build all artefacts
+  annotate             Validate annotations and print the route map to stdout
+
+Flags:
+  -h, --help           Show this help message
+
+Run 'vyx <command> -help' for command-specific flags.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "new":
+		runNew(os.Args[2:])
+	case "dev":
+		runDev(os.Args[2:])
+	case "build":
+		runBuild(os.Args[2:])
+	case "annotate":
+		runAnnotate(os.Args[2:])
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "error: unknown command %q\n\n", os.Args[1])
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #5. Also closes #33 (tech debt: `vyx new project` generates default `vyx.yaml`).

Implements the unified `vyx` CLI as a standalone Go module at `cmd/vyx/`. All four subcommands are wired through a single entry point.

---

## Architecture

```
cmd/vyx/
  main.go           ← entry point, subcommand dispatch, usage help
  cmd_new.go        ← vyx new project <name>
  cmd_dev.go        ← vyx dev
  cmd_build.go      ← vyx build
  cmd_annotate.go   ← vyx annotate (+ shared runCommand helper)
  cmd_new_test.go   ← 5 integration tests
  go.mod            ← module github.com/ElioNeto/vyx/cli
```

---

## Subcommands

### `vyx new project <name>` (closes #33)

Scaffolds the full project tree and writes a `vyx.yaml` seeded from the canonical defaults defined in `core/domain/config`:

```
<name>/
├── core/
├── backend/{go,node,python}/
├── frontend/src/
├── schemas/
└── vyx.yaml
```

The generated `vyx.yaml` is validated at write time (YAML parse round-trip). `project.name` is set from `<name>`.

### `vyx dev`

Builds the core binary into `.vyx/core`, launches it as a child process with `VYX_ENV=development` and `VYX_CONFIG` set, and forwards `SIGINT`/`SIGTERM` for graceful shutdown. The core's own `SIGHUP` reload remains available.

### `vyx build`

Runs the annotation scanner across `backend/go`, `backend/node`, and `frontend/src`, writes `route_map.json`, then builds the core binary. Exits non-zero on any annotation error.

### `vyx annotate`

Runs the scanner and prints discovered routes as a human-readable table. Pass `--json` for machine-readable output. Exits non-zero on validation errors.

---

## Acceptance Criteria

- [x] `vyx new project <name>` — scaffolds directory structure with core, backend (go/node/python), frontend, schemas and `vyx.yaml`
- [x] `vyx dev` — starts the core in development mode with hot reload and verbose logging
- [x] `vyx build` — runs annotation scanner, generates `route_map.json`, builds core binary
- [x] `vyx annotate` — validates all annotations and prints the discovered route map to stdout
- [x] All commands report errors clearly with actionable messages
- [x] `vyx new project` generates a valid `vyx.yaml` seeded from defaults (closes #33)

---

## Tests (`cmd_new_test.go`)

| Test | Coverage |
|---|---|
| `TestScaffoldProject_CreatesDirectoryTree` | All required dirs and `vyx.yaml` are created |
| `TestScaffoldProject_VyxYAML_IsValid` | Generated YAML is parseable; all sections present; `project.name` matches arg |
| `TestScaffoldProject_AlreadyExists_ReturnsError` | Duplicate project name returns error |
| `TestDefaultVyxYAML_ContainsProjectName` | `project.name` is injected correctly |
| `TestDefaultVyxYAML_IsValidYAML` | Template produces valid YAML |

---

## Install

```bash
cd cmd/vyx && go install .
# or
go build -o vyx ./cmd/vyx && mv vyx /usr/local/bin/
```

## Run Tests

```bash
cd cmd/vyx && go test ./...
```