### PR TITLE
fix(cli,heartbeat): wire real scanner in cmdBuild/cmdAnnotate + add heartbeat Receiver (#48 #49)

### DIFF
--- a/core/application/heartbeat/receiver.go
+++ b/core/application/heartbeat/receiver.go
@@ -1,0 +1,150 @@
+package heartbeat
+
+import (
+	"context"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// Receiver starts one heartbeat.Loop per live worker and keeps the set of
+// running loops in sync with the worker repository.
+//
+// Design: Receiver is intentionally separate from Sender so that the two
+// traffic directions (core→worker and worker→core) can be reasoned about
+// independently. Receiver satisfies spec §5.4: "Workers send periodic
+// heartbeats every 5s to the core."
+type Receiver struct {
+	transport ipc.Transport
+	lister    WorkerLister
+	service   LifecycleService
+	cfg       Config
+	log       *zap.Logger
+
+	mu      sync.Mutex
+	running map[string]context.CancelFunc // workerID → loop cancel
+}
+
+// NewReceiver creates a Receiver wired with all required dependencies.
+func NewReceiver(
+	transport ipc.Transport,
+	lister WorkerLister,
+	service LifecycleService,
+	cfg Config,
+	log *zap.Logger,
+) *Receiver {
+	return &Receiver{
+		transport: transport,
+		lister:    lister,
+		service:   service,
+		cfg:       cfg,
+		log:       log,
+		running:   make(map[string]context.CancelFunc),
+	}
+}
+
+// Run reconciles the set of running heartbeat loops with the live worker list
+// on every tick. New workers get a loop; workers that disappeared have their
+// loop cancelled. Blocks until ctx is cancelled.
+func (r *Receiver) Run(ctx context.Context) {
+	// Kick off loops for workers that are already alive at startup.
+	r.reconcile(ctx)
+
+	ticker := newTicker(r.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.stopAll()
+			return
+		case <-ticker.C:
+			r.reconcile(ctx)
+		}
+	}
+}
+
+// StartLoop manually starts a heartbeat read loop for workerID. This is the
+// hook called by main.go right after a worker is spawned so we do not have to
+// wait for the next reconcile tick.
+func (r *Receiver) StartLoop(ctx context.Context, workerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.running[workerID]; ok {
+		return // loop already running
+	}
+	r.launchLocked(ctx, workerID)
+}
+
+// reconcile starts loops for workers that do not have one yet and cancels
+// loops for workers that are no longer alive.
+func (r *Receiver) reconcile(ctx context.Context) {
+	ids, err := r.lister.LiveWorkerIDs(ctx)
+	if err != nil {
+		r.log.Error("heartbeat receiver: failed to list workers", zap.Error(err))
+		return
+	}
+
+	live := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		live[id] = struct{}{}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Start loops for newly appeared workers.
+	for id := range live {
+		if _, ok := r.running[id]; !ok {
+			r.launchLocked(ctx, id)
+		}
+	}
+
+	// Cancel loops for workers that are no longer in the live set.
+	for id, cancel := range r.running {
+		if _, ok := live[id]; !ok {
+			cancel()
+			delete(r.running, id)
+			r.log.Info("heartbeat receiver: stopped loop for departed worker",
+				zap.String("worker_id", id),
+			)
+		}
+	}
+}
+
+// launchLocked starts a Loop goroutine for workerID. Caller must hold r.mu.
+func (r *Receiver) launchLocked(ctx context.Context, workerID string) {
+	loopCtx, cancel := context.WithCancel(ctx)
+	r.running[workerID] = cancel
+
+	loop := New(workerID, r.transport, r.service, r.cfg, r.log)
+	go func() {
+		defer func() {
+			r.mu.Lock()
+			delete(r.running, workerID)
+			r.mu.Unlock()
+		}()
+		loop.Run(loopCtx)
+	}()
+
+	r.log.Info("heartbeat receiver: started loop",
+		zap.String("worker_id", workerID),
+	)
+}
+
+// stopAll cancels every running loop. Called when the root context is done.
+func (r *Receiver) stopAll() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for id, cancel := range r.running {
+		cancel()
+		delete(r.running, id)
+		r.log.Info("heartbeat receiver: stopped loop on shutdown",
+			zap.String("worker_id", id),
+		)
+	}
+}

--- a/core/application/heartbeat/receiver_test.go
+++ b/core/application/heartbeat/receiver_test.go
@@ -1,0 +1,200 @@
+package heartbeat_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ElioNeto/vyx/core/application/heartbeat"
+	"github.com/ElioNeto/vyx/core/domain/ipc"
+)
+
+// ─── fakes ───────────────────────────────────────────────────────────────────
+
+type fakeTransport struct {
+	mu   sync.Mutex
+	msgs map[string][]ipc.Message // workerID → queued messages
+}
+
+func newFakeTransport() *fakeTransport {
+	return &fakeTransport{msgs: make(map[string][]ipc.Message)}
+}
+
+func (f *fakeTransport) Send(_ context.Context, workerID string, msg ipc.Message) error {
+	f.mu.Lock()
+	f.msgs[workerID] = append(f.msgs[workerID], msg)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeTransport) Receive(ctx context.Context, workerID string) (ipc.Message, error) {
+	for {
+		f.mu.Lock()
+		if len(f.msgs[workerID]) > 0 {
+			msg := f.msgs[workerID][0]
+			f.msgs[workerID] = f.msgs[workerID][1:]
+			f.mu.Unlock()
+			return msg, nil
+		}
+		f.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ipc.Message{}, ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func (f *fakeTransport) Register(_ context.Context, _ string) error  { return nil }
+func (f *fakeTransport) Deregister(_ context.Context, _ string) error { return nil }
+func (f *fakeTransport) Close() error                                  { return nil }
+
+// ─── fakes for WorkerLister and LifecycleService ─────────────────────────────
+
+type fakeLister struct {
+	mu  sync.Mutex
+	ids []string
+}
+
+func (f *fakeLister) LiveWorkerIDs(_ context.Context) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	result := make([]string, len(f.ids))
+	copy(result, f.ids)
+	return result, nil
+}
+
+type fakeService struct {
+	mu         sync.Mutex
+	heartbeats []string
+	unhealthy  []string
+}
+
+func (f *fakeService) RecordHeartbeat(_ context.Context, workerID string) error {
+	f.mu.Lock()
+	f.heartbeats = append(f.heartbeats, workerID)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeService) MarkUnhealthy(_ context.Context, workerID string) error {
+	f.mu.Lock()
+	f.unhealthy = append(f.unhealthy, workerID)
+	f.mu.Unlock()
+	return nil
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+func TestReceiver_StartLoop_RecordsHeartbeat(t *testing.T) {
+	transport := newFakeTransport()
+	lister := &fakeLister{ids: []string{"w1"}}
+	svc := &fakeService{}
+	log := zap.NewNop()
+
+	cfg := heartbeat.Config{Interval: 50 * time.Millisecond, MissedThreshold: 3}
+	recv := heartbeat.NewReceiver(transport, lister, svc, cfg, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Pre-queue a TypeHeartbeat frame for w1.
+	transport.Send(ctx, "w1", ipc.Message{Type: ipc.TypeHeartbeat})
+
+	// Start a loop for w1 directly.
+	recv.StartLoop(ctx, "w1")
+
+	// Give the loop time to process the frame.
+	time.Sleep(80 * time.Millisecond)
+
+	svc.mu.Lock()
+	got := len(svc.heartbeats)
+	svc.mu.Unlock()
+
+	if got == 0 {
+		t.Fatal("expected at least one RecordHeartbeat call, got none")
+	}
+}
+
+func TestReceiver_MissedBeats_MarksUnhealthy(t *testing.T) {
+	transport := newFakeTransport()
+	lister := &fakeLister{ids: []string{"w2"}}
+	svc := &fakeService{}
+	log := zap.NewNop()
+
+	// Very short interval so the test finishes fast; threshold = 2 misses.
+	cfg := heartbeat.Config{Interval: 20 * time.Millisecond, MissedThreshold: 2}
+	recv := heartbeat.NewReceiver(transport, lister, svc, cfg, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Do NOT queue any frames — every read will time out (missed heartbeat).
+	recv.StartLoop(ctx, "w2")
+
+	// Wait long enough for 2 missed beats + margin.
+	time.Sleep(120 * time.Millisecond)
+
+	svc.mu.Lock()
+	unhealthyCalls := len(svc.unhealthy)
+	svc.mu.Unlock()
+
+	if unhealthyCalls == 0 {
+		t.Fatal("expected MarkUnhealthy to be called after missed threshold, got none")
+	}
+}
+
+func TestReceiver_ContextCancellation_StopsGracefully(t *testing.T) {
+	transport := newFakeTransport()
+	lister := &fakeLister{ids: []string{"w3"}}
+	svc := &fakeService{}
+	log := zap.NewNop()
+
+	cfg := heartbeat.Config{Interval: 100 * time.Millisecond, MissedThreshold: 5}
+	recv := heartbeat.NewReceiver(transport, lister, svc, cfg, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		recv.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// clean exit
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Receiver.Run did not return after context cancellation")
+	}
+}
+
+func TestReceiver_ListerError_DoesNotPanic(t *testing.T) {
+	transport := newFakeTransport()
+	lister := &errorLister{}
+	svc := &fakeService{}
+	log := zap.NewNop()
+
+	cfg := heartbeat.Config{Interval: 20 * time.Millisecond, MissedThreshold: 2}
+	recv := heartbeat.NewReceiver(transport, lister, svc, cfg, log)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
+	defer cancel()
+
+	// Should not panic even if lister always errors.
+	recv.Run(ctx)
+}
+
+type errorLister struct{}
+
+func (e *errorLister) LiveWorkerIDs(_ context.Context) ([]string, error) {
+	return nil, errors.New("repository unavailable")
+}

--- a/core/application/heartbeat/ticker.go
+++ b/core/application/heartbeat/ticker.go
@@ -1,0 +1,19 @@
+package heartbeat
+
+import "time"
+
+// ticker wraps time.Ticker so that tests can substitute a fake.
+// Production code uses newTicker which returns a real *time.Ticker.
+type ticker interface {
+	Stop()
+	Chan() <-chan time.Time
+}
+
+type realTicker struct{ t *time.Ticker }
+
+func (r *realTicker) Stop()                  { r.t.Stop() }
+func (r *realTicker) Chan() <-chan time.Time  { return r.t.C }
+
+func newTicker(d time.Duration) ticker {
+	return &realTicker{t: time.NewTicker(d)}
+}

--- a/core/cmd/vyx/main.go
+++ b/core/cmd/vyx/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -25,8 +26,8 @@ import (
 	"github.com/ElioNeto/vyx/core/application/heartbeat"
 	"github.com/ElioNeto/vyx/core/application/lifecycle"
 	"github.com/ElioNeto/vyx/core/application/monitor"
-	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
 	doamincfg "github.com/ElioNeto/vyx/core/domain/config"
+	dgw "github.com/ElioNeto/vyx/core/domain/gateway"
 	infracfg "github.com/ElioNeto/vyx/core/infrastructure/config"
 	infragw "github.com/ElioNeto/vyx/core/infrastructure/gateway"
 	"github.com/ElioNeto/vyx/core/infrastructure/ipc/uds"
@@ -107,14 +108,12 @@ func cmdNew(name string) {
 		fatalf("vyx new: write vyx.yaml: %v", err)
 	}
 
-	// Create directory skeleton.
 	for _, dir := range []string{"workers", "schemas"} {
 		if err := os.MkdirAll(filepath.Join(name, dir), 0755); err != nil {
 			fatalf("vyx new: create %s: %v", dir, err)
 		}
 	}
 
-	// Write a minimal README.
 	readme := fmt.Sprintf("# %s\n\nCreated with `vyx new %s`.\n\nRun `cd %s && vyx dev` to start in development mode.\n", name, name, name)
 	if err := os.WriteFile(filepath.Join(name, "README.md"), []byte(readme), 0644); err != nil {
 		fatalf("vyx new: write README: %v", err)
@@ -133,21 +132,17 @@ func cmdBuild() {
 	if _, err := os.Stat("workers"); err == nil {
 		tsDir = "workers"
 	}
+	if _, err := os.Stat("backend/go"); err == nil {
+		goDir = "backend/go"
+	}
 
 	output := cfg.Build.RouteMapOutput
 	if output == "" {
 		output = "./route_map.json"
 	}
 
-	errs, err := generateRouteMap(goDir, tsDir, output)
-	if err != nil {
+	if err := runAnnotateCmd(goDir, tsDir, output); err != nil {
 		fatalf("vyx build: %v", err)
-	}
-	if len(errs) > 0 {
-		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "  annotation error: %v\n", e)
-		}
-		os.Exit(1)
 	}
 	fmt.Printf("✓ route_map.json written to %s\n", output)
 }
@@ -167,18 +162,10 @@ func cmdAnnotate() {
 		output = "./route_map.json"
 	}
 
-	errs, err := generateRouteMap("", tsDir, output)
-	if err != nil {
+	if err := runAnnotateCmd("", tsDir, output); err != nil {
 		fatalf("vyx annotate: %v", err)
 	}
-	if len(errs) > 0 {
-		for _, e := range errs {
-			fmt.Fprintf(os.Stderr, "  annotation error: %v\n", e)
-		}
-		os.Exit(1)
-	}
 
-	// Read back and pretty-print to stdout.
 	data, err := os.ReadFile(output)
 	if err != nil {
 		fatalf("vyx annotate: read output: %v", err)
@@ -190,6 +177,52 @@ func cmdAnnotate() {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(pretty)
+}
+
+// runAnnotateCmd invokes the vyx annotation scanner via os/exec.
+//
+// Strategy: shell out to `go run github.com/ElioNeto/vyx/cmd/annotate` so
+// that the core module does not need a direct import of the scanner module.
+// This keeps the core's dependency graph clean and avoids replace-directive
+// coupling between the two modules.
+//
+// Flags forwarded to cmd/annotate:
+//
+//	--go-dir   <dir>    directory containing Go source files with @Route annotations
+//	--ts-dir   <dir>    directory containing TypeScript/JavaScript files with @Route annotations
+//	--output   <file>   path where route_map.json will be written
+func runAnnotateCmd(goDir, tsDir, output string) error {
+	// Build argument list.
+	args := []string{
+		"run", "github.com/ElioNeto/vyx/cmd/annotate",
+		"--output", output,
+	}
+	if goDir != "" {
+		args = append(args, "--go-dir", goDir)
+	}
+	if tsDir != "" {
+		args = append(args, "--ts-dir", tsDir)
+	}
+
+	cmd := exec.Command("go", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		// Provide a helpful hint when the scanner binary is not installed.
+		var exitErr *exec.ExitError
+		if strings.Contains(err.Error(), "no required module") ||
+			(func() bool {
+				if ok := errors.As(err, &exitErr); ok {
+					return exitErr.ExitCode() == 127
+				}
+				return false
+			}()) {
+			return fmt.Errorf("scanner binary not found — run `go install github.com/ElioNeto/vyx/cmd/annotate@latest`: %w", err)
+		}
+		return err
+	}
+	return nil
 }
 
 // ─── vyx dev / vyx start ─────────────────────────────────────────────────────
@@ -243,7 +276,7 @@ func runServer(devMode bool) {
 	cfgLoader.WithRouteMap(routeMapPath, rm)
 	log.Info("route map loaded", zap.String("path", routeMapPath))
 
-	// --- Infrastructure: UDS transport (#45) ---
+	// --- Infrastructure: UDS transport ---
 	socketDir := cfg.IPC.SocketDir
 	if socketDir == "" {
 		socketDir = uds.DefaultSocketDir
@@ -266,7 +299,7 @@ func runServer(devMode bool) {
 	jwtValidator := infragw.NewJWTValidator([]byte(jwtSecret))
 	schemaValidator := infragw.NewSchemaValidator(cfg.Build.SchemasDir)
 
-	// --- Dispatcher (#45) ---
+	// --- Dispatcher ---
 	dispatcher := apgw.NewDispatcher(
 		rm,
 		transport,
@@ -283,7 +316,7 @@ func runServer(devMode bool) {
 		time.Minute,
 	)
 
-	// --- HTTP server (#43 — dev=h2c, prod=H2+TLS) ---
+	// --- HTTP server (dev=h2c, prod=H2+TLS) ---
 	var gwCfg infragw.Config
 	if devMode {
 		gwCfg = infragw.DevConfig()
@@ -292,13 +325,13 @@ func runServer(devMode bool) {
 	}
 	httpServer := infragw.New(gwCfg, dispatcher, rateLimiter, log)
 
-	// --- Heartbeat sender (#38, #45) ---
-	hbSender := heartbeat.NewSender(
-		transport,
-		repo,
-		heartbeat.Config{Interval: 5 * time.Second},
-		log,
-	)
+	hbCfg := heartbeat.Config{Interval: 5 * time.Second, MissedThreshold: 2}
+
+	// --- Heartbeat sender (core → worker) ---
+	hbSender := heartbeat.NewSender(transport, repo, hbCfg, log)
+
+	// --- Heartbeat receiver (worker → core) (#49) ---
+	hbReceiver := heartbeat.NewReceiver(transport, repo, service, hbCfg, log)
 
 	// --- Context + signal handling ---
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -316,7 +349,7 @@ func runServer(devMode bool) {
 		)
 	}
 
-	// --- Auto-spawn workers from vyx.yaml (#44) ---
+	// --- Auto-spawn workers from vyx.yaml ---
 	for _, wcfg := range cfg.Workers {
 		replicas := wcfg.Replicas
 		if replicas <= 0 {
@@ -328,7 +361,6 @@ func runServer(devMode bool) {
 				workerID = fmt.Sprintf("%s-%d", wcfg.ID, i)
 			}
 
-			// Register UDS socket before spawning so the worker can connect.
 			if err := transport.Register(ctx, workerID); err != nil {
 				log.Error("failed to register UDS socket for worker",
 					zap.String("worker_id", workerID), zap.Error(err))
@@ -338,11 +370,9 @@ func runServer(devMode bool) {
 			args := parseArgs(wcfg.Command)
 			cmd := args[0]
 			cmdArgs := args[1:]
-			// Inject socket path via env so the worker SDK knows where to connect.
 			cmdArgs = append(cmdArgs, "--vyx-socket",
 				filepath.Join(socketDir, workerID+".sock"))
 
-			// Apply startup timeout.
 			spawnCtx := ctx
 			if wcfg.StartupTimeout > 0 {
 				var cancel context.CancelFunc
@@ -364,6 +394,9 @@ func runServer(devMode bool) {
 				zap.String("command", wcfg.Command),
 				zap.Int("replica", i),
 			)
+
+			// Start the worker→core heartbeat read loop immediately (#49).
+			hbReceiver.StartLoop(ctx, w.ID)
 		}
 	}
 
@@ -371,6 +404,7 @@ func runServer(devMode bool) {
 	go healthMonitor.Run(ctx)
 	go cfgLoader.WatchSIGHUP(ctx)
 	go hbSender.Run(ctx)
+	go hbReceiver.Run(ctx) // reconciles any workers added after startup
 
 	// Start HTTP server.
 	go func() {
@@ -385,7 +419,6 @@ func runServer(devMode bool) {
 		}
 	}()
 
-	// Block until signal.
 	<-ctx.Done()
 	log.Info("vyx core shutting down — draining workers")
 
@@ -421,37 +454,9 @@ func mustLoadConfig() *doamincfg.Config {
 	return cfg
 }
 
-// parseArgs splits a command string into argv, honouring quoted segments.
 func parseArgs(command string) []string {
 	return strings.Fields(command)
 }
-
-// generateRouteMap shells out to the scanner package.
-// The scanner lives in a separate module so we call it via its public API.
-func generateRouteMap(goDir, tsDir, output string) ([]annotationError, error) {
-	// The scanner module is separate; here we compile-call via os/exec.
-	// Direct import is avoided to keep core/ independent of scanner/.
-	// If scanner is vendored into core, replace with direct scanner.Generate call.
-	var errs []annotationError
-
-	// For now, produce an empty route map when no workers directory exists.
-	if goDir == "" && tsDir == "" {
-		if err := os.WriteFile(output, []byte(`{"routes":[]}`), 0644); err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
-
-	// Write empty map as placeholder; real scan done via CLI tool.
-	if err := os.WriteFile(output, []byte(`{"routes":[]}`), 0644); err != nil {
-		return nil, err
-	}
-	return errs, nil
-}
-
-type annotationError struct{ msg string }
-
-func (e annotationError) Error() string { return e.msg }
 
 func fatalf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "vyx: "+format+"\n", args...)


### PR DESCRIPTION
## Summary

Fixes two Phase 1 gaps identified in the post-merge audit:

- **#48** — `cmdBuild` / `cmdAnnotate` were writing an empty `{"routes":[]}` placeholder instead of invoking the real annotation scanner.
- **#49** — The worker→core heartbeat direction (spec §5.4) had no read loop; only the core→worker `Sender` existed.

---

## Changes

### #48 — Real scanner wired into `cmdBuild` / `cmdAnnotate`

**`core/cmd/vyx/main.go`**

- Removed the `generateRouteMap` stub that wrote `{"routes":[]}` unconditionally.
- Added `runAnnotateCmd(goDir, tsDir, output string) error` which calls:
  ```
  go run github.com/ElioNeto/vyx/cmd/annotate \
      --go-dir <dir> --ts-dir <dir> --output <file>
  ```
  This keeps `core/` independent of the `scanner/` module (no `replace` directive needed) while still invoking the real scanner at build time.
- Improved error message when the scanner binary is not installed:
  ```
  scanner binary not found — run `go install github.com/ElioNeto/vyx/cmd/annotate@latest`
  ```
- `cmdBuild` also detects `backend/go` as a Go source directory (in addition to `workers`).

---

### #49 — Heartbeat Receiver (worker → core)

**`core/application/heartbeat/receiver.go`** _(new)_

- `Receiver` manages a map of running `heartbeat.Loop` goroutines, one per live worker.
- `Run(ctx)` reconciles on every tick: starts loops for newly appeared workers, cancels loops for workers that have disappeared.
- `StartLoop(ctx, workerID)` is a hook called by `main.go` immediately after spawning a worker, so the read loop is active before the first heartbeat arrives (no tick delay).
- All loop lifecycle (start/stop/cleanup) is protected by a `sync.Mutex`.

**`core/application/heartbeat/ticker.go`** _(new)_

- Thin `ticker` interface wrapping `*time.Ticker` to allow substitution in future tests.

**`core/application/heartbeat/receiver_test.go`** _(new)_

Four test cases:
1. `TestReceiver_StartLoop_RecordsHeartbeat` — verifies that a `TypeHeartbeat` frame triggers `RecordHeartbeat`.
2. `TestReceiver_MissedBeats_MarksUnhealthy` — verifies that `MissedThreshold` consecutive timeouts trigger `MarkUnhealthy`.
3. `TestReceiver_ContextCancellation_StopsGracefully` — verifies `Run` returns cleanly when the context is cancelled.
4. `TestReceiver_ListerError_DoesNotPanic` — verifies resilience when the worker repository is temporarily unavailable.

**`core/cmd/vyx/main.go`**

- `heartbeat.NewReceiver(transport, repo, service, hbCfg, log)` instantiated alongside `Sender`.
- `hbReceiver.StartLoop(ctx, w.ID)` called for each successfully spawned worker.
- `go hbReceiver.Run(ctx)` started as a background goroutine (reconciles future workers).

---

## Checklist

- [x] #48 — `cmdBuild` and `cmdAnnotate` invoke `cmd/annotate` via `os/exec`
- [x] #48 — Helpful error message when scanner is not installed
- [x] #49 — `heartbeat.Receiver` starts one `Loop` per live worker
- [x] #49 — `StartLoop` hook called immediately after each worker spawn
- [x] #49 — 4 unit tests in `receiver_test.go`
- [x] No new external dependencies added to `core/go.mod`

Closes #48, closes #49